### PR TITLE
Simplifying SimulatedRamp and using change event

### DIFF
--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -49,7 +49,6 @@ public class BocciaModel : Singleton<BocciaModel>
     // Change events
     public static event System.Action WasChanged;
 
-
     // Hardware interface
     // TODO - create this based on game mode (live or sim)
     private RampController rampController = new SimulatedRamp();
@@ -78,15 +77,14 @@ public class BocciaModel : Singleton<BocciaModel>
     // BackPressed()
 
     // Game control
+    public void RotateBy(float degrees) => rampController.RotateBy(degrees);
+    public void ElevateBy(float elevation) => rampController.ElevateBy(elevation);
+
     public void RandomColor()
     {
         bocciaData.BallColor = UnityEngine.Random.ColorHSV();
         SendChangeEvent();
     }
-
-    public void RotateLeft() => rampController.RotateLeft();
-    public void RotateRight() => rampController.RotateRight();
-
 
     // BCI control
 

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.VisualScripting;
+using UnityEditor.UI;
 using UnityEngine;
 
 
@@ -67,14 +68,17 @@ public class BocciaModel : Singleton<BocciaModel>
         }
 
         SendChangeEvent();
+
+        // For now, just emit change event if ramp changes
+        rampController.RampChanged += SendChangeEvent;
+    }
+
+    private void OnDisable()
+    {
+        rampController.RampChanged -= SendChangeEvent;
     }
 
 
-    // Navigation control
-
-    // ShowGameOptions()
-    // ShowBciOptions()
-    // BackPressed()
 
     // Game control
     public void RotateBy(float degrees) => rampController.RotateBy(degrees);
@@ -86,27 +90,26 @@ public class BocciaModel : Singleton<BocciaModel>
         SendChangeEvent();
     }
 
-    // BCI control
+    // Navigation control
 
-    // StartTraining()
-    // StopTraining()
+
+    // BCI control
 
 
     // Ramp Hardware
-    // SetSerialPort(name)
-    // CalibrateRamp(part)
 
 
-    // Bind replaces the current gameData with another one.  This is used
-    // to provide the model with a BocciaData loaded from disk, etc.
+    // Persistence
     public void Bind(BocciaData gameData)
     {
+        // Bind replaces the current gameData with another one.  This is used
+        // to provide the model with a BocciaData loaded from disk, etc.
         this.bocciaData = gameData;
         SendChangeEvent();
     }
 
 
-    // Helpers
+    // MARK: Helpers
     private void SendChangeEvent()
     {
         WasChanged?.Invoke();

--- a/Boccia-Unity/Assets/Boccia/Model/RampController.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/RampController.cs
@@ -2,6 +2,8 @@
 // Interface for an object that manages a ramp (simulated or hardware)
 public interface RampController
 {
+    public event System.Action RampChanged;
+
     public float Rotation { get; }
     public float Elevation { get; }
 

--- a/Boccia-Unity/Assets/Boccia/Model/RampController.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/RampController.cs
@@ -5,8 +5,8 @@ public interface RampController
     public float Rotation { get; }
     public float Elevation { get; }
 
-    public void RotateLeft();
-    public void RotateRight();
+    public void RotateBy(float degrees);
+    public void ElevateBy(float elevation);
 
     // add remaining methods like calibration, test, reset
 }

--- a/Boccia-Unity/Assets/Boccia/Model/SimulatedRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/SimulatedRamp.cs
@@ -19,25 +19,13 @@ public class SimulatedRamp: RampController
         Elevation = 0.0f;
     }
 
-    public void RotateLeft()
+    public void RotateBy(float degrees)
     {
-        RotateRamp(-30.0f);
+        Rotation += degrees;
     }
 
-    public void RotateRight()
+    public void ElevateBy(float elevation)
     {
-        RotateRamp(30.0f);
-    }
-
-    // This task will produce the desired change in rotation over a few steps
-    private async void RotateRamp(float rotationDegrees)
-    {
-        float startRotation = Rotation;
-        float rotationStep = Math.Sign(rotationDegrees) * 1.0f;
-        while(Math.Abs(Rotation - startRotation) <= Math.Abs(rotationDegrees))
-        {
-            await Task.Delay(100);
-            Rotation += rotationStep;
-        }
+        Elevation += elevation;
     }
 }

--- a/Boccia-Unity/Assets/Boccia/Model/SimulatedRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/SimulatedRamp.cs
@@ -8,8 +8,10 @@ using UnityEngine.UIElements;
 
 // Simulate a ramp.  This uses Tasks instead of MonoBehavior.Update() to be more like a
 // hardware ramp where updates may be driven by serial port events (independent of Unity)
-public class SimulatedRamp: RampController
+public class SimulatedRamp : RampController
 {
+    public event System.Action RampChanged;
+
     public float Rotation { get; private set; }
     public float Elevation { get; private set; }
 
@@ -22,10 +24,17 @@ public class SimulatedRamp: RampController
     public void RotateBy(float degrees)
     {
         Rotation += degrees;
+        SendChangeEvent();
     }
 
     public void ElevateBy(float elevation)
     {
         Elevation += elevation;
+        SendChangeEvent();
+    }
+
+    private void SendChangeEvent()
+    {
+        RampChanged?.Invoke();
     }
 }

--- a/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
@@ -29,15 +29,12 @@ public class RampPresenter : MonoBehaviour
         BocciaModel.WasChanged -= ModelChanged;
     }
 
-    void Update()
+    private void ModelChanged()
     {
         // Ramp is a digital twin, so we just match visualization with model data
         ramp.transform.rotation = Quaternion.AngleAxis(model.RampRotation, Vector3.up);
         ramp.transform.rotation *= Quaternion.AngleAxis(model.RampElevation, Vector3.right);
-    }
 
-    private void ModelChanged()
-    {
         // For lower rate changes, update when model sends change event
         ball.GetComponent<Renderer>().material.color = model.BallColor;
     }

--- a/Boccia-Unity/Assets/Boccia/UI/ExamplePresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/ExamplePresenter.cs
@@ -7,7 +7,7 @@ using UnityEngine.UI;
 // This is an example UI presenter.  This could be broken into several smaller scripts
 // that each reference their own local UI element.  Typically there's interaction between
 // UI elements, so can be more convenient to keep the logic in a single presenter.
-public class PlayPresenter : MonoBehaviour
+public class ExamplePresenter : MonoBehaviour
 {
     // TODO - This is a dummy example, replace with real ramp prefab object, etc
     public Button rotateLeftButton;
@@ -24,8 +24,8 @@ public class PlayPresenter : MonoBehaviour
         BocciaModel.WasChanged += ModelChanged;
 
         // connect buttons to model
-        rotateLeftButton.onClick.AddListener(model.RotateLeft);
-        rotateRightButton.onClick.AddListener(model.RotateRight);
+        rotateLeftButton.onClick.AddListener(RotateRight);
+        rotateRightButton.onClick.AddListener(RotateLeft);
         colorButton.onClick.AddListener(model.RandomColor);
     }
 
@@ -44,6 +44,18 @@ public class PlayPresenter : MonoBehaviour
         // For a presenter, this is usually used to refresh the UI to reflect the
         // state of the model (UI does not store state, it just provides a way
         // to view and change it)
+    }
+
+    // Somehow we'll have to figure out the amount of rotation by looking at what SPO was clicked
+    // Perhaps the SPO onCLick can provide the value that's initialized when the fan is created?
+    private void RotateRight()
+    {
+        model.RotateBy(10.0f);
+    }
+
+    private void RotateLeft()
+    {
+        model.RotateBy(-10.0f);
     }
 
 }

--- a/Boccia-Unity/Assets/Boccia/UI/ExamplePresenter.cs.meta
+++ b/Boccia-Unity/Assets/Boccia/UI/ExamplePresenter.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: be13d79d50d6a43828aaaecdfbe44efc
+guid: 3a14970601ce544be92d2517dfee5174
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Boccia-Unity/Assets/Scenes/SampleScene.unity
+++ b/Boccia-Unity/Assets/Scenes/SampleScene.unity
@@ -253,7 +253,7 @@ GameObject:
   - component: {fileID: 215524016}
   - component: {fileID: 215524015}
   m_Layer: 0
-  m_Name: PlayCanvas
+  m_Name: ExampleCanvas
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -288,7 +288,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 215524013}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: be13d79d50d6a43828aaaecdfbe44efc, type: 3}
+  m_Script: {fileID: 11500000, guid: 3a14970601ce544be92d2517dfee5174, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   rotateLeftButton: {fileID: 1730103702}


### PR DESCRIPTION
RampController can change elevation and rotation (only rotation used in my example)

SimulatedRamp just sets the reported rotation/elevation and signals to BocciaModel that data has changed.  BocciaModel then emits a changed event for the rest of the application to consume.

The 3D ramp (presenter, etc) will handle smoothly rotating/elevating ramp to the new reported position.
