### PR TITLE
Virtual play camera shows ball

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
@@ -311,6 +311,7 @@ public class FanGenerator : MonoBehaviour
     {
         GameObject textObject = new ("TextAnnotation");
         textObject.transform.SetParent(this.transform);
+        textObject.layer = LayerMask.NameToLayer("VirtualPlayUI");
         textObject.transform.SetLocalPositionAndRotation
         (
             position,

--- a/Boccia-Unity/Assets/Boccia/UI/ExamplePresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/ExamplePresenter.cs
@@ -19,8 +19,10 @@ public class ExamplePresenter : MonoBehaviour
     public Button dropBallButton;
     public Button colorButton;
     public Button randomJackButton;
-    public Button toggleCameraButton;
+    private List<Button> virtualPlayButtons;
 
+
+    public Button toggleCameraButton;
     public Camera VirtualPlayCamera;
 
     private BocciaModel model;
@@ -32,6 +34,21 @@ public class ExamplePresenter : MonoBehaviour
         model = BocciaModel.Instance;
         model.WasChanged += ModelChanged;
 
+        // Create a list of the virtual play buttons
+        // Do not include the camera toggle button
+        virtualPlayButtons = new List<Button>()
+        {
+            rotateLeftButton,
+            rotateRightButton,
+            moveUpButton,
+            moveDownButton,
+            resetRampButton,
+            resetBallButton,
+            dropBallButton,
+            colorButton,
+            randomJackButton,
+        };
+
         // connect buttons to model
         rotateLeftButton.onClick.AddListener(RotateLeft);
         rotateRightButton.onClick.AddListener(RotateRight);
@@ -42,6 +59,8 @@ public class ExamplePresenter : MonoBehaviour
         dropBallButton.onClick.AddListener(model.DropBall);
         colorButton.onClick.AddListener(model.RandomColor);
         randomJackButton.onClick.AddListener(model.RandomJackBall);
+
+        // Connect the camera toggle button
         toggleCameraButton.onClick.AddListener(ToggleCamera);
     }
 
@@ -87,14 +106,44 @@ public class ExamplePresenter : MonoBehaviour
 
     private void ToggleCamera()
     {
+        // Check if the camera is enabled, if it is disable it
+        // If it is disabled, enable it
         if (VirtualPlayCamera.gameObject.activeSelf)
         {
+            // Disable camera
             VirtualPlayCamera.gameObject.SetActive(false);
+
+            // Allow virtual play buttons and fan to be interactable
+            ToggleVirtualPlayButtons(true);
+            ToggleFan(true);
         }
+
         else
         {
+            // Enable camera
             VirtualPlayCamera.gameObject.SetActive(true);
+
+            // Prevent virtual play buttons and fan from being interactable
+            ToggleVirtualPlayButtons(false);
+            ToggleFan(false);
         }
     }
 
+    private void ToggleVirtualPlayButtons(bool isInteractable)
+    {
+        virtualPlayButtons.ForEach(colorButton => colorButton.interactable = isInteractable);
+    }
+
+    private void ToggleFan(bool isInteractable)
+    {
+        GameObject[] fanSegments = GameObject.FindGameObjectsWithTag("BCI");
+        foreach (GameObject fanSegment in fanSegments)
+        {
+            MeshCollider segmentCollider = fanSegment.GetComponent<MeshCollider>();
+            if (segmentCollider != null)
+            {
+                segmentCollider.enabled = isInteractable;
+            }
+        }
+    }
 }

--- a/Boccia-Unity/Assets/Boccia/UI/ExamplePresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/ExamplePresenter.cs
@@ -19,6 +19,9 @@ public class ExamplePresenter : MonoBehaviour
     public Button dropBallButton;
     public Button colorButton;
     public Button randomJackButton;
+    public Button toggleCameraButton;
+
+    public Camera VirtualPlayCamera;
 
     private BocciaModel model;
 
@@ -39,6 +42,7 @@ public class ExamplePresenter : MonoBehaviour
         dropBallButton.onClick.AddListener(model.DropBall);
         colorButton.onClick.AddListener(model.RandomColor);
         randomJackButton.onClick.AddListener(model.RandomJackBall);
+        toggleCameraButton.onClick.AddListener(ToggleCamera);
     }
 
 
@@ -79,6 +83,18 @@ public class ExamplePresenter : MonoBehaviour
     private void MoveDown()
     {
         model.ElevateBy(-1.0f);
+    }
+
+    private void ToggleCamera()
+    {
+        if (VirtualPlayCamera.gameObject.activeSelf)
+        {
+            VirtualPlayCamera.gameObject.SetActive(false);
+        }
+        else
+        {
+            VirtualPlayCamera.gameObject.SetActive(true);
+        }
     }
 
 }

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
@@ -186,7 +186,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Toggle View
+  m_text: Toggle Court View
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -900,7 +900,7 @@ RectTransform:
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
   m_AnchoredPosition: {x: -120, y: 159}
-  m_SizeDelta: {x: 180, y: 40}
+  m_SizeDelta: {x: 220, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6300852364910776983
 CanvasRenderer:

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
@@ -18,7 +18,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &8546668943168392915
 RectTransform:
   m_ObjectHideFlags: 0
@@ -407,7 +407,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &7133282708478586337
 RectTransform:
   m_ObjectHideFlags: 0
@@ -545,12 +545,12 @@ RectTransform:
   - {fileID: 1609435497391829437}
   - {fileID: 1493494056422143403}
   - {fileID: 3689214675342381772}
+  - {fileID: 4241648512545941290}
   - {fileID: 8546668943168392915}
   - {fileID: 7133282708478586337}
   - {fileID: 5390435838549941340}
   - {fileID: 5256700391486419048}
   - {fileID: 1829385295331621794}
-  - {fileID: 4241648512545941290}
   m_Father: {fileID: 7764173004061172451}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -639,7 +639,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &5390435838549941340
 RectTransform:
   m_ObjectHideFlags: 0
@@ -760,7 +760,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &5256700391486419048
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2104,7 +2104,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1829385295331621794
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 1662291164201609081}
   - component: {fileID: 7255551528062080240}
   - component: {fileID: 3638648145732925411}
-  m_Layer: 5
+  m_Layer: 6
   m_Name: RotateLeftButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -132,7 +132,7 @@ GameObject:
   - component: {fileID: 4987319783403007938}
   - component: {fileID: 541563345441665998}
   - component: {fileID: 9118872938388128138}
-  m_Layer: 5
+  m_Layer: 6
   m_Name: Text (TMP)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -267,7 +267,7 @@ GameObject:
   - component: {fileID: 249098529428390987}
   - component: {fileID: 8130608554664654786}
   - component: {fileID: 2745594877561296081}
-  m_Layer: 5
+  m_Layer: 6
   m_Name: RotateRightButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -388,7 +388,7 @@ GameObject:
   - component: {fileID: 8930885327393908749}
   - component: {fileID: 9082072509012217209}
   - component: {fileID: 2425395178984046}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: VirtualPlayButtons
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -498,7 +498,7 @@ GameObject:
   - component: {fileID: 3117854110211536374}
   - component: {fileID: 6405692512174425727}
   - component: {fileID: 1020736014239196524}
-  m_Layer: 5
+  m_Layer: 6
   m_Name: DropBallButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -619,7 +619,7 @@ GameObject:
   - component: {fileID: 2988690553297689026}
   - component: {fileID: 6546182808659880523}
   - component: {fileID: 871235478745336152}
-  m_Layer: 5
+  m_Layer: 6
   m_Name: MoveDownButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -739,7 +739,7 @@ GameObject:
   - component: {fileID: 7215231919838661182}
   - component: {fileID: 2779608417862719026}
   - component: {fileID: 6889272956980339830}
-  m_Layer: 5
+  m_Layer: 6
   m_Name: Text (TMP)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -873,7 +873,7 @@ GameObject:
   - component: {fileID: 8300388496401159162}
   - component: {fileID: 6842541188488807831}
   - component: {fileID: 5810994096325976250}
-  m_Layer: 5
+  m_Layer: 6
   m_Name: Text (TMP)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1008,7 +1008,7 @@ GameObject:
   - component: {fileID: 3931406161124561486}
   - component: {fileID: 5591672340010151945}
   - component: {fileID: 5307156225035156463}
-  m_Layer: 5
+  m_Layer: 6
   m_Name: RandomJackButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1128,7 +1128,7 @@ GameObject:
   - component: {fileID: 7636728249483625527}
   - component: {fileID: 3119195692288317499}
   - component: {fileID: 5927055510026463871}
-  m_Layer: 5
+  m_Layer: 6
   m_Name: Text (TMP)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1261,7 +1261,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7764173004061172451}
   - component: {fileID: 3576948454555312335}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: VirtualPlayScreen
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1316,7 +1316,7 @@ GameObject:
   - component: {fileID: 1325976998643012212}
   - component: {fileID: 5824369394957618808}
   - component: {fileID: 3016544763743255612}
-  m_Layer: 5
+  m_Layer: 6
   m_Name: Text (TMP)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1451,7 +1451,7 @@ GameObject:
   - component: {fileID: 6063160319026526717}
   - component: {fileID: 2847942383612381812}
   - component: {fileID: 8163365981475531111}
-  m_Layer: 5
+  m_Layer: 6
   m_Name: BallColorButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1571,7 +1571,7 @@ GameObject:
   - component: {fileID: 433345867803767110}
   - component: {fileID: 4949752653941583178}
   - component: {fileID: 4447788080809385742}
-  m_Layer: 5
+  m_Layer: 6
   m_Name: Text (TMP)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1705,7 +1705,7 @@ GameObject:
   - component: {fileID: 6139616106081645403}
   - component: {fileID: 359990545204764032}
   - component: {fileID: 3336116435331724033}
-  m_Layer: 5
+  m_Layer: 6
   m_Name: Text (TMP)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1840,7 +1840,7 @@ GameObject:
   - component: {fileID: 8712551189683360264}
   - component: {fileID: 813026763785691521}
   - component: {fileID: 6739501676030411410}
-  m_Layer: 5
+  m_Layer: 6
   m_Name: MoveUpButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1960,7 +1960,7 @@ GameObject:
   - component: {fileID: 4203827744979821513}
   - component: {fileID: 8711227331690872773}
   - component: {fileID: 138702821955177857}
-  m_Layer: 5
+  m_Layer: 6
   m_Name: Text (TMP)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2095,7 +2095,7 @@ GameObject:
   - component: {fileID: 8445251991010630657}
   - component: {fileID: 473668909283045256}
   - component: {fileID: 5790848212467436699}
-  m_Layer: 5
+  m_Layer: 6
   m_Name: ResetRampButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2215,7 +2215,7 @@ GameObject:
   - component: {fileID: 4065588270397755389}
   - component: {fileID: 8852210896846590961}
   - component: {fileID: 275252330239238581}
-  m_Layer: 5
+  m_Layer: 6
   m_Name: Text (TMP)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2350,7 +2350,7 @@ GameObject:
   - component: {fileID: 1194208003963516333}
   - component: {fileID: 2229748811494752026}
   - component: {fileID: 8216782688655078050}
-  m_Layer: 5
+  m_Layer: 6
   m_Name: ResetBallsButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
@@ -121,6 +121,140 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &1000861959202839204
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6048656857237724832}
+  - component: {fileID: 6676506235099004806}
+  - component: {fileID: 5278407252515761016}
+  m_Layer: 6
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6048656857237724832
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000861959202839204}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4241648512545941290}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6676506235099004806
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000861959202839204}
+  m_CullTransparentMesh: 1
+--- !u!114 &5278407252515761016
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000861959202839204}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Change View
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 0
+  m_fontSizeMax: 0
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &1311153157770674488
 GameObject:
   m_ObjectHideFlags: 0
@@ -416,6 +550,7 @@ RectTransform:
   - {fileID: 5390435838549941340}
   - {fileID: 5256700391486419048}
   - {fileID: 1829385295331621794}
+  - {fileID: 4241648512545941290}
   m_Father: {fileID: 7764173004061172451}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -725,6 +860,127 @@ MonoBehaviour:
     m_DisabledTrigger: Disabled
   m_Interactable: 1
   m_TargetGraphic: {fileID: 6546182808659880523}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &3676631831203774032
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4241648512545941290}
+  - component: {fileID: 6300852364910776983}
+  - component: {fileID: 6972816661474649290}
+  - component: {fileID: 22244603314456237}
+  m_Layer: 6
+  m_Name: ToggleViewButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4241648512545941290
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3676631831203774032}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6048656857237724832}
+  m_Father: {fileID: 3678344975101463026}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: -120, y: 159}
+  m_SizeDelta: {x: 160, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6300852364910776983
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3676631831203774032}
+  m_CullTransparentMesh: 1
+--- !u!114 &6972816661474649290
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3676631831203774032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &22244603314456237
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3676631831203774032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 6972816661474649290}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -1305,6 +1561,8 @@ MonoBehaviour:
   dropBallButton: {fileID: 1020736014239196524}
   colorButton: {fileID: 8163365981475531111}
   randomJackButton: {fileID: 0}
+  toggleCameraButton: {fileID: 22244603314456237}
+  VirtualPlayCamera: {fileID: 0}
 --- !u!1 &4999685241904479374
 GameObject:
   m_ObjectHideFlags: 0

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
@@ -186,7 +186,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Change View
+  m_text: Toggle View
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -900,7 +900,7 @@ RectTransform:
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
   m_AnchoredPosition: {x: -120, y: 159}
-  m_SizeDelta: {x: 160, y: 60}
+  m_SizeDelta: {x: 180, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6300852364910776983
 CanvasRenderer:

--- a/Boccia-Unity/Assets/Boccia/UI/ScreenSwitcher.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/ScreenSwitcher.cs
@@ -8,7 +8,6 @@ using UnityEngine;
 public class ScreenSwitcher : MonoBehaviour
 {
     public Camera ScreenCamera;
-    public Camera VirtualPlayCamera;
     public float CameraDistance = 600.0f;
     public float RampViewCameraDistance = 5.0f; // Custom distance so the camera will view the ramp
     public float CameraSpeed = 5.0f;
@@ -67,38 +66,31 @@ public class ScreenSwitcher : MonoBehaviour
         {
             case BocciaScreen.PlayMenu:
                 PanCameraToScreen(PlayMenu, RampViewCameraDistance);
-                EnableVirtualPlayCamera(false);
                 break;
                 
             case BocciaScreen.HamburgerMenu:
                 PanCameraToScreen(HamburgerMenuOptions, RampViewCameraDistance);
-                EnableVirtualPlayCamera(false);
                 break;
 
             case BocciaScreen.TrainingScreen:
                 PanCameraToScreen(TrainingScreen, RampViewCameraDistance);
-                EnableVirtualPlayCamera(false);
                 break;
 
             case BocciaScreen.VirtualPlay:
                 PanCameraToScreen(VirtualPlayScreen, RampViewCameraDistance);
-                EnableVirtualPlayCamera(true);
                 break;
 
             case BocciaScreen.GameOptions:
                 PanCameraToScreen(GameOptionsMenu, RampViewCameraDistance);
-                EnableVirtualPlayCamera(false);
                 break;
 
             case BocciaScreen.BciOptions:
                 PanCameraToScreen(BciOptionsMenu, RampViewCameraDistance);
-                EnableVirtualPlayCamera(false);
                 break;
             
             // For now just switch back to start menu to show switching works
             default:
                 PanCameraToScreen(StartMenu, CameraDistance);
-                EnableVirtualPlayCamera(false);
                 break;
         }
     }
@@ -153,12 +145,4 @@ public class ScreenSwitcher : MonoBehaviour
         }
         ScreenCamera.transform.rotation = targetRotation;
     }
-
-    // Helper method to toggle the virtual play camera on or off
-    // VirtualPlayCamera should only be enabled for the virtual play screen
-    private void EnableVirtualPlayCamera(bool isEnabled)
-    {
-        VirtualPlayCamera.gameObject.SetActive(isEnabled);
-    }
-
 }

--- a/Boccia-Unity/Assets/Boccia/UI/ScreenSwitcher.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/ScreenSwitcher.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 public class ScreenSwitcher : MonoBehaviour
 {
     public Camera ScreenCamera;
+    public Camera VirtualPlayCamera;
     public float CameraDistance = 600.0f;
     public float RampViewCameraDistance = 5.0f; // Custom distance so the camera will view the ramp
     public float CameraSpeed = 5.0f;
@@ -66,31 +67,38 @@ public class ScreenSwitcher : MonoBehaviour
         {
             case BocciaScreen.PlayMenu:
                 PanCameraToScreen(PlayMenu, RampViewCameraDistance);
+                EnableVirtualPlayCamera(false);
                 break;
                 
             case BocciaScreen.HamburgerMenu:
                 PanCameraToScreen(HamburgerMenuOptions, RampViewCameraDistance);
+                EnableVirtualPlayCamera(false);
                 break;
 
             case BocciaScreen.TrainingScreen:
                 PanCameraToScreen(TrainingScreen, RampViewCameraDistance);
+                EnableVirtualPlayCamera(false);
                 break;
 
             case BocciaScreen.VirtualPlay:
                 PanCameraToScreen(VirtualPlayScreen, RampViewCameraDistance);
+                EnableVirtualPlayCamera(true);
                 break;
 
             case BocciaScreen.GameOptions:
                 PanCameraToScreen(GameOptionsMenu, RampViewCameraDistance);
+                EnableVirtualPlayCamera(false);
                 break;
 
             case BocciaScreen.BciOptions:
                 PanCameraToScreen(BciOptionsMenu, RampViewCameraDistance);
+                EnableVirtualPlayCamera(false);
                 break;
             
             // For now just switch back to start menu to show switching works
             default:
                 PanCameraToScreen(StartMenu, CameraDistance);
+                EnableVirtualPlayCamera(false);
                 break;
         }
     }
@@ -144,6 +152,13 @@ public class ScreenSwitcher : MonoBehaviour
             yield return null;
         }
         ScreenCamera.transform.rotation = targetRotation;
+    }
+
+    // Helper method to toggle the virtual play camera on or off
+    // VirtualPlayCamera should only be enabled for the virtual play screen
+    private void EnableVirtualPlayCamera(bool isEnabled)
+    {
+        VirtualPlayCamera.gameObject.SetActive(isEnabled);
     }
 
 }

--- a/Boccia-Unity/Assets/Boccia/World/VirtualPlayCamera.prefab
+++ b/Boccia-Unity/Assets/Boccia/World/VirtualPlayCamera.prefab
@@ -62,8 +62,8 @@ Camera:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 0.25
-    height: 0.3
+    width: 0.3
+    height: 0.5
   near clip plane: 0.3
   far clip plane: 1000
   field of view: 60

--- a/Boccia-Unity/Assets/Boccia/World/VirtualPlayCamera.prefab
+++ b/Boccia-Unity/Assets/Boccia/World/VirtualPlayCamera.prefab
@@ -17,7 +17,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &8216061330022203258
 Transform:
   m_ObjectHideFlags: 0

--- a/Boccia-Unity/Assets/Boccia/World/VirtualPlayCamera.prefab
+++ b/Boccia-Unity/Assets/Boccia/World/VirtualPlayCamera.prefab
@@ -62,14 +62,14 @@ Camera:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1
-    height: 1
+    width: 0.25
+    height: 0.3
   near clip plane: 0.3
   far clip plane: 1000
   field of view: 60
   orthographic: 0
   orthographic size: 5
-  m_Depth: -1
+  m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
     m_Bits: 4294967295

--- a/Boccia-Unity/Assets/Boccia/World/VirtualPlayCamera.prefab
+++ b/Boccia-Unity/Assets/Boccia/World/VirtualPlayCamera.prefab
@@ -72,7 +72,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 63
+    m_Bits: 55
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0

--- a/Boccia-Unity/Assets/Boccia/World/VirtualPlayCamera.prefab
+++ b/Boccia-Unity/Assets/Boccia/World/VirtualPlayCamera.prefab
@@ -62,8 +62,8 @@ Camera:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 0.3
-    height: 0.5
+    width: 0.45
+    height: 0.75
   near clip plane: 0.3
   far clip plane: 1000
   field of view: 60

--- a/Boccia-Unity/Assets/Boccia/World/VirtualPlayCamera.prefab
+++ b/Boccia-Unity/Assets/Boccia/World/VirtualPlayCamera.prefab
@@ -1,0 +1,94 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8488096547483231996
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8216061330022203258}
+  - component: {fileID: 8042703545872246154}
+  - component: {fileID: 1522569282520239427}
+  m_Layer: 0
+  m_Name: VirtualPlayCamera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8216061330022203258
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8488096547483231996}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: -0.742, y: -0.814, z: 0.165}
+--- !u!20 &8042703545872246154
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8488096547483231996}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!81 &1522569282520239427
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8488096547483231996}
+  m_Enabled: 0

--- a/Boccia-Unity/Assets/Boccia/World/VirtualPlayCamera.prefab
+++ b/Boccia-Unity/Assets/Boccia/World/VirtualPlayCamera.prefab
@@ -72,7 +72,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 63
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0

--- a/Boccia-Unity/Assets/Boccia/World/VirtualPlayCamera.prefab.meta
+++ b/Boccia-Unity/Assets/Boccia/World/VirtualPlayCamera.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4709d4f0887c783479110c4deab2b320
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
+++ b/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
@@ -3388,23 +3388,23 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 4.71
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 7.9
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -10
+      value: 10.8
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.9529133
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: 0.3032431
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalRotation.y
@@ -3416,15 +3416,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -0.742
+      value: 35.305
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.814
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 0.165
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8488096547483231996, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_Name

--- a/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
+++ b/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
@@ -227,98 +227,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7029420362845547233, guid: 0a09a675c7fdc9c40884ccfb0e22c2db, type: 3}
   m_PrefabInstance: {fileID: 51956293}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &57528122
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 57528125}
-  - component: {fileID: 57528124}
-  - component: {fileID: 57528123}
-  m_Layer: 0
-  m_Name: VirtualPlayCamera
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!81 &57528123
-AudioListener:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 57528122}
-  m_Enabled: 0
---- !u!20 &57528124
-Camera:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 57528122}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
-  m_projectionMatrixMode: 1
-  m_GateFitMode: 2
-  m_FOVAxisMode: 0
-  m_Iso: 200
-  m_ShutterSpeed: 0.005
-  m_Aperture: 16
-  m_FocusDistance: 10
-  m_FocalLength: 50
-  m_BladeCount: 5
-  m_Curvature: {x: 2, y: 11}
-  m_BarrelClipping: 0.25
-  m_Anamorphism: 0
-  m_SensorSize: {x: 36, y: 24}
-  m_LensShift: {x: 0, y: 0}
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
-  near clip plane: 0.3
-  far clip plane: 1000
-  field of view: 60
-  orthographic: 0
-  orthographic size: 5
-  m_Depth: -1
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
-  m_TargetDisplay: 0
-  m_TargetEye: 3
-  m_HDR: 1
-  m_AllowMSAA: 1
-  m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 0
-  m_OcclusionCulling: 1
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
---- !u!4 &57528125
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 57528122}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -10}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: -0.742, y: -0.814, z: 0.165}
 --- !u!1 &126370150
 GameObject:
   m_ObjectHideFlags: 0
@@ -3470,12 +3378,69 @@ MonoBehaviour:
   BciOptionsMenu: {fileID: 458797266}
   VirtualPlayScreen: {fileID: 738463301}
   TrainingScreen: {fileID: 1609661544}
+--- !u!1001 &2466695322583312716
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -0.742
+      objectReference: {fileID: 0}
+    - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.814
+      objectReference: {fileID: 0}
+    - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0.165
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488096547483231996, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
+      propertyPath: m_Name
+      value: VirtualPlayCamera
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 963194228}
-  - {fileID: 57528125}
+  - {fileID: 2466695322583312716}
   - {fileID: 887964981}
   - {fileID: 566192212}
   - {fileID: 126370152}

--- a/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
+++ b/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
@@ -227,6 +227,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7029420362845547233, guid: 0a09a675c7fdc9c40884ccfb0e22c2db, type: 3}
   m_PrefabInstance: {fileID: 51956293}
   m_PrefabAsset: {fileID: 0}
+--- !u!20 &57528124 stripped
+Camera:
+  m_CorrespondingSourceObject: {fileID: 8042703545872246154, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
+  m_PrefabInstance: {fileID: 2466695322583312716}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &126370150
 GameObject:
   m_ObjectHideFlags: 0
@@ -3368,6 +3373,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ScreenCamera: {fileID: 963194227}
+  VirtualPlayCamera: {fileID: 57528124}
   CameraDistance: 8
   RampViewCameraDistance: 5
   CameraSpeed: 5

--- a/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
+++ b/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
@@ -1657,7 +1657,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2859724575470018110, guid: 6a619933318bf764aa5fb150788918f3, type: 3}
       propertyPath: m_Layer
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 3576948454555312335, guid: 6a619933318bf764aa5fb150788918f3, type: 3}
       propertyPath: randomJackButton

--- a/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
+++ b/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
@@ -3402,27 +3402,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 10.8
+      value: 14.54
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9529133
+      value: 0.9292643
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.3032431
+      value: 0.36941555
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 35.305
+      value: 43.359
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y

--- a/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
+++ b/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
@@ -1668,6 +1668,10 @@ PrefabInstance:
       propertyPath: randomJackButton
       value: 
       objectReference: {fileID: 1803754786}
+    - target: {fileID: 3576948454555312335, guid: 6a619933318bf764aa5fb150788918f3, type: 3}
+      propertyPath: VirtualPlayCamera
+      value: 
+      objectReference: {fileID: 57528124}
     - target: {fileID: 3678344975101463026, guid: 6a619933318bf764aa5fb150788918f3, type: 3}
       propertyPath: m_SizeDelta.x
       value: 1000
@@ -3373,7 +3377,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   ScreenCamera: {fileID: 963194227}
-  VirtualPlayCamera: {fileID: 57528124}
   CameraDistance: 8
   RampViewCameraDistance: 5
   CameraSpeed: 5

--- a/Boccia-Unity/ProjectSettings/TagManager.asset
+++ b/Boccia-Unity/ProjectSettings/TagManager.asset
@@ -17,7 +17,7 @@ TagManager:
   - Interactable
   - Water
   - UI
-  - 
+  - VirtualPlayUI
   - 
   - 
   - 


### PR DESCRIPTION
[BOC-78](https://bci4kids.atlassian.net/browse/BOC-78?atlOrigin=eyJpIjoiNGM4MWU4MGRlNmFhNDE5ZmJjOTZjMDU1ZTlhZmY3MTgiLCJwIjoiaiJ9)

The Toggle View button in Virtual Play enables/disables a secondary VirtualPlayCamera that views the full Boccia court, to show where the balls and jack are located. The camera display takes up a portion of the main screen when it is turned on. The default is to have it turned off. 

The Virtual Play UI elements (the fan and other buttons) aren't visible in the VirtualPlayCamera, but I can change that if need be or if it makes more sense. 

I also disabled the buttons in Virtual Play that are no longer necessary, i.e. rotate left/right, elevate up/down, and the original drop ball buttons, since this can now be handled with the fan. I did not remove the functionality of those temporary buttons from ExamplePresenter, so if they are needed again for testing, they can be re-enabled.