### PR TITLE
Leave training when completed

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/LSLMonitor.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/LSLMonitor.cs
@@ -1,0 +1,41 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using LSL;
+using BCIEssentials.LSLFramework;
+
+public class LSLMonitor : MonoBehaviour
+{
+    private BocciaModel _model;
+    private LSLMarkerStream _markerStream;
+    private StreamInlet _streamInlet;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        _model = BocciaModel.Instance;
+        
+        _markerStream = GetComponent<LSLMarkerStream>();
+        string streamName = _markerStream.StreamName;
+        string streamType = _markerStream.StreamType;
+        string streamID = _markerStream.StreamId;
+        LSL.StreamInfo streamInfo = new LSL.StreamInfo(streamName, streamType, 1, 0.0, LSL.channel_format_t.cf_string, streamID);
+
+        _streamInlet = new StreamInlet(streamInfo);
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        string[] sample = new string[1];
+        double timestamp = _streamInlet.pull_sample(sample, 0.0f);
+
+        if (timestamp != 0.0f)
+        {
+            if (sample[0].Contains("Training Complete"))
+            {
+                _model.SetBciTrained();
+            }
+        }
+    }
+}

--- a/Boccia-Unity/Assets/Boccia/BCI/LSLMonitor.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/LSLMonitor.cs
@@ -13,27 +13,36 @@ public class LSLMonitor : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
+        // cache model
         _model = BocciaModel.Instance;
-        
+
+        // Initialize the LSL marker stream
         _markerStream = GetComponent<LSLMarkerStream>();
         string streamName = _markerStream.StreamName;
         string streamType = _markerStream.StreamType;
         string streamID = _markerStream.StreamId;
         LSL.StreamInfo streamInfo = new LSL.StreamInfo(streamName, streamType, 1, 0.0, LSL.channel_format_t.cf_string, streamID);
 
+        // Initialize the stream inlet for the LSL marker stream
         _streamInlet = new StreamInlet(streamInfo);
     }
 
     // Update is called once per frame
     void Update()
     {
+        // Place to store the stream samples
         string[] sample = new string[1];
-        double timestamp = _streamInlet.pull_sample(sample, 0.0f);
 
-        if (timestamp != 0.0f)
+        // Pull the stream sample
+        double streamSample = _streamInlet.pull_sample(sample, 0.0f);
+
+        // Process the stream sample
+        if (streamSample != 0.0f)
         {
+            // Check for the Training Complete marker
             if (sample[0].Contains("Training Complete"))
             {
+                // If training is complete, update BciTrained flag
                 _model.SetBciTrained();
             }
         }

--- a/Boccia-Unity/Assets/Boccia/BCI/LSLMonitor.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/LSLMonitor.cs
@@ -73,8 +73,8 @@ public class LSLMonitor : MonoBehaviour
                 // Check for the Training Complete marker
                 if (sample[0].Contains("Training Complete"))
                 {
-                    // If training is complete, update BciTrained flag
-                    _model.SetBciTrained();
+                    // If training is complete, update the model
+                    _model.TrainingComplete();
 
                     // Stop the coroutine
                     _sampleStreamCoroutine = null;

--- a/Boccia-Unity/Assets/Boccia/BCI/LSLMonitor.cs.meta
+++ b/Boccia-Unity/Assets/Boccia/BCI/LSLMonitor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e84af0d649a928443b662abe23f64dbd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -267,7 +267,7 @@ public class BocciaModel : Singleton<BocciaModel>
     }
 
     // Update training status when training is complete
-    public void SetBciTrained()
+    public void TrainingComplete()
     {
         IsTraining = false;
         BciTrained = true;

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -257,7 +257,7 @@ public class BocciaModel : Singleton<BocciaModel>
         SendBciChangeEvent();
     }
 
-    // Training status
+    // Update training status when training is complete
     public void SetBciTrained()
     {
         BciTrained = true;

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -257,6 +257,13 @@ public class BocciaModel : Singleton<BocciaModel>
         SendBciChangeEvent();
     }
 
+    // Training status
+    public void SetBciTrained()
+    {
+        BciTrained = true;
+        SendBciChangeEvent();
+    }
+
     // MARK: BCI Setting Defaults
     private void SetDefaultP300Settings()
     // Set default values for P300 settings

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -37,6 +37,9 @@ public class BocciaModel : Singleton<BocciaModel>
     // Access to the current BCI Paradigm
     public BocciaBciParadigm Paradigm => bocciaData.Paradigm;  // Read-only property
 
+    // BCI Training state
+    public bool IsTraining { get; private set; }
+
     // Paradigm agnostic tracker for whether BCI Training has been done
     // get is public, set is private
     public bool BciTrained { get; private set; }
@@ -257,9 +260,16 @@ public class BocciaModel : Singleton<BocciaModel>
         SendBciChangeEvent();
     }
 
+    public void TrainingStarted()
+    {
+        IsTraining = true;
+        SendBciChangeEvent();
+    }
+
     // Update training status when training is complete
     public void SetBciTrained()
     {
+        IsTraining = false;
         BciTrained = true;
         SendBciChangeEvent();
     }

--- a/Boccia-Unity/Assets/Boccia/UI/HamburgerMenuPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/HamburgerMenuPresenter.cs
@@ -22,6 +22,7 @@ public class HamburgerMenuPresenter : MonoBehaviour
     {
         // Cache model and subscribe for changed event
         model = BocciaModel.Instance;
+        model.BciChanged += BciChanged;
 
         // Connect buttons to model
         hamburgerButton.onClick.AddListener(model.ShowHamburgerMenu);
@@ -29,5 +30,33 @@ public class HamburgerMenuPresenter : MonoBehaviour
         gameOptionsButton.onClick.AddListener(model.ShowGameOptions); // Need to change this to show game options
         bciOptionsButton.onClick.AddListener(model.ShowBciOptions);  // Need to change this to show BCI options
         quitButton.onClick.AddListener(model.QuitGame);
+    }
+
+    void OnEnable()
+    {
+        if (model != null)
+        {
+            model.BciChanged += BciChanged;
+        }
+    }
+
+    void OnDisable()
+    {
+        if (model != null)  
+        {
+            model.BciChanged -= BciChanged;
+        }
+    }
+
+    private void BciChanged()
+    {
+        if (model.IsTraining == true)
+        {
+            hamburgerButton.interactable = false;
+        }
+        else 
+        {
+            hamburgerButton.interactable = true;
+        }
     }
 }

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/HamburgerMenu.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/HamburgerMenu.prefab
@@ -1142,7 +1142,7 @@ MonoBehaviour:
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.15686275}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:

--- a/Boccia-Unity/Assets/Boccia/UI/TrainingPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/TrainingPresenter.cs
@@ -22,6 +22,7 @@ public class TrainingPresenter : MonoBehaviour
         // cache model and subscribe for changed event
         _model = BocciaModel.Instance;
         _model.WasChanged += ModelChanged;
+        _model.BciChanged += TrainingComplete;
 
         // Generate the fan
         //fanPresenter.GenerateFan();
@@ -38,6 +39,15 @@ public class TrainingPresenter : MonoBehaviour
         // For a presenter, this is usually used to refresh the UI to reflect the
         // state of the model (UI does not store state, it just provides a way
         // to view and change it)
+    }
+
+    private void TrainingComplete()
+    {
+        // Go back to Play Menu when training is done
+        if (_model.BciTrained == true)
+        {
+            _model.PlayMenu();
+        }
     }
 
     void Update()

--- a/Boccia-Unity/Assets/Boccia/UI/TrainingPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/TrainingPresenter.cs
@@ -22,7 +22,7 @@ public class TrainingPresenter : MonoBehaviour
         // cache model and subscribe for changed event
         _model = BocciaModel.Instance;
         _model.WasChanged += ModelChanged;
-        _model.BciChanged += TrainingComplete;
+        _model.BciChanged += BciChanged;
 
         // Generate the fan
         //fanPresenter.GenerateFan();
@@ -34,7 +34,7 @@ public class TrainingPresenter : MonoBehaviour
         if (_model != null)
         {
             _model.WasChanged += ModelChanged;
-            _model.BciChanged += TrainingComplete;
+            _model.BciChanged += BciChanged;
         }
     }
 
@@ -42,7 +42,7 @@ public class TrainingPresenter : MonoBehaviour
     void OnDisable()
     {
         _model.WasChanged -= ModelChanged;
-        _model.BciChanged -= TrainingComplete;
+        _model.BciChanged -= BciChanged;
     }
 
     private void ModelChanged()
@@ -52,7 +52,7 @@ public class TrainingPresenter : MonoBehaviour
         // to view and change it)
     }
 
-    private void TrainingComplete()
+    private void BciChanged()
     {
         // Go back to Play Menu when training is done
         if (_model.BciTrained == true)

--- a/Boccia-Unity/Assets/Boccia/UI/TrainingPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/TrainingPresenter.cs
@@ -28,10 +28,21 @@ public class TrainingPresenter : MonoBehaviour
         //fanPresenter.GenerateFan();
     }
 
+    void OnEnable()
+    {
+        // Subscribe to events on enable
+        if (_model != null)
+        {
+            _model.WasChanged += ModelChanged;
+            _model.BciChanged += TrainingComplete;
+        }
+    }
+
 
     void OnDisable()
     {
         _model.WasChanged -= ModelChanged;
+        _model.BciChanged -= TrainingComplete;
     }
 
     private void ModelChanged()
@@ -46,6 +57,7 @@ public class TrainingPresenter : MonoBehaviour
         // Go back to Play Menu when training is done
         if (_model.BciTrained == true)
         {
+            // Update the on screen text
             instructionText.GetComponent<TextMeshProUGUI>().text = "Training complete.";
             StartCoroutine(BackToPlayMenu());
         }
@@ -55,6 +67,7 @@ public class TrainingPresenter : MonoBehaviour
     {
         // Wait before switching to Play Menu so the user can see the text
         yield return new WaitForSecondsRealtime(5f);
+        // Call the method that navigates to Play Menu
         _model.PlayMenu();
     }
 
@@ -64,13 +77,6 @@ public class TrainingPresenter : MonoBehaviour
         if (Input.GetKeyDown(KeyCode.T))
         {
             instructionText.GetComponent<TextMeshProUGUI>().text = "Training triggered.";
-        }
-
-        // Temporary to test setting BciTrained and switching to Play Menu
-        if (Input.GetKeyDown(KeyCode.C))
-        {
-            _model.SetBciTrained();
-            Debug.Log("BciTrained: " + _model.BciTrained);
         }
     }
 }

--- a/Boccia-Unity/Assets/Boccia/UI/TrainingPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/TrainingPresenter.cs
@@ -65,5 +65,12 @@ public class TrainingPresenter : MonoBehaviour
         {
             instructionText.GetComponent<TextMeshProUGUI>().text = "Training triggered.";
         }
+
+        // Temporary to test setting BciTrained and switching to Play Menu
+        if (Input.GetKeyDown(KeyCode.C))
+        {
+            _model.SetBciTrained();
+            Debug.Log("BciTrained: " + _model.BciTrained);
+        }
     }
 }

--- a/Boccia-Unity/Assets/Boccia/UI/TrainingPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/TrainingPresenter.cs
@@ -76,7 +76,7 @@ public class TrainingPresenter : MonoBehaviour
         // If t is pressed, update the instruction text
         if (Input.GetKeyDown(KeyCode.T))
         {
-            instructionText.GetComponent<TextMeshProUGUI>().text = "Training triggered.";
+            instructionText.GetComponent<TextMeshProUGUI>().text = "Training in progress.";
             _model.TrainingStarted();
         }
     }

--- a/Boccia-Unity/Assets/Boccia/UI/TrainingPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/TrainingPresenter.cs
@@ -47,8 +47,15 @@ public class TrainingPresenter : MonoBehaviour
         if (_model.BciTrained == true)
         {
             instructionText.GetComponent<TextMeshProUGUI>().text = "Training complete.";
-            _model.PlayMenu();
+            StartCoroutine(BackToPlayMenu());
         }
+    }
+
+    private IEnumerator BackToPlayMenu()
+    {
+        // Wait before switching to Play Menu so the user can see the text
+        yield return new WaitForSecondsRealtime(5f);
+        _model.PlayMenu();
     }
 
     void Update()

--- a/Boccia-Unity/Assets/Boccia/UI/TrainingPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/TrainingPresenter.cs
@@ -77,6 +77,7 @@ public class TrainingPresenter : MonoBehaviour
         if (Input.GetKeyDown(KeyCode.T))
         {
             instructionText.GetComponent<TextMeshProUGUI>().text = "Training triggered.";
+            _model.TrainingStarted();
         }
     }
 }

--- a/Boccia-Unity/Assets/Boccia/UI/TrainingPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/TrainingPresenter.cs
@@ -46,6 +46,7 @@ public class TrainingPresenter : MonoBehaviour
         // Go back to Play Menu when training is done
         if (_model.BciTrained == true)
         {
+            instructionText.GetComponent<TextMeshProUGUI>().text = "Training complete.";
             _model.PlayMenu();
         }
     }

--- a/Boccia-Unity/Assets/Samples/BCI Essentials/1.1.6/Controller Hotswapping Example/Prefabs/ControllerManager.prefab
+++ b/Boccia-Unity/Assets/Samples/BCI Essentials/1.1.6/Controller Hotswapping Example/Prefabs/ControllerManager.prefab
@@ -180,6 +180,7 @@ GameObject:
   - component: {fileID: 5532972415090187197}
   - component: {fileID: 5532972415090187194}
   - component: {fileID: 5532972415090187195}
+  - component: {fileID: 870782259031274312}
   m_Layer: 0
   m_Name: ControllerManager
   m_TagString: Untagged
@@ -250,6 +251,18 @@ MonoBehaviour:
   _targetStreamName: PythonResponse
   _resolveTimeout: 1
   _pollFrequency: 0
+--- !u!114 &870782259031274312
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1649985292535673242}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e84af0d649a928443b662abe23f64dbd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1649985293060537292
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
For the task: [BOC-67](https://bci4kids.atlassian.net/browse/BOC-67?atlOrigin=eyJpIjoiMmI2YTQ4N2RhNmRmNDU1ZDlkYTFkNDk1ZjExODBiNjIiLCJwIjoiaiJ9)

When training is completed, the training scene "disappears" by switching back to the Play Menu (as described in [UI Mockups | Training](https://bci4kids.atlassian.net/wiki/spaces/Boccia/pages/186384420/UI+Mockups#Training)). 

Changes made:

- In `TrainingPresenter`, when T is pressed to begin training, it also calls a new method in the model called `TrainingStarted()`
- Added a new `IsTraining` bool flag to the model, which is set to true by `model.TrainingStarted()`. `IsTraining` keeps track of whether or not training is in progress. 
- Created the `LSLMonitor.cs` script (located in Assets/Boccia/BCI) to read the `LSLMarkerStream` and update the model when it receives the ("Training Complete") marker, by calling the `model.TrainingComplete()` method. LSLMonitor only reads the stream if `IsTraining == true`. 
- Added the `TrainingComplete()` method to `BocciaModel` which sets `IsTraining` to false, and `BciTrained` to true. 
- When training is complete, `TrainingPresenter` updates the training instruction text, and then switches the screen back to the play menu. 
- Added to `HamburgerMenuPresenter` to deactivate the Hamburger Menu when `IsTraining == true`. This prevents the user from navigating away from the training screen while training is still in progress. 
- `LSLMonitor`, `TrainingPresenter`, and `HamburgerMenuPresenter` all subscribe to the `BciChanged` event. The `TrainingStarted()` and `TrainingComplete()` methods in `BocciaModel` both send out this event. 