### PR TITLE
Training completed before play

### DIFF
--- a/Boccia-Unity/Assets/Boccia/UI/PlayMenuPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayMenuPresenter.cs
@@ -32,6 +32,7 @@ public class PlayMenuPresenter : MonoBehaviour
     private void BciChanged()
     {
         // Turn on Play and Virtual Play buttons only when training is complete
+        /*
         if (_model.BciTrained == true)
         {
             playBocciaButton.interactable = true;
@@ -43,5 +44,6 @@ public class PlayMenuPresenter : MonoBehaviour
             playBocciaButton.interactable = false;
             virtualPlayButton.interactable = false;
         }
+        */
     }
 }

--- a/Boccia-Unity/Assets/Boccia/UI/PlayMenuPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayMenuPresenter.cs
@@ -9,18 +9,39 @@ public class PlayMenuPresenter : MonoBehaviour
     public Button playBocciaButton;
     public Button virtualPlayButton;
 
-    private BocciaModel model;
+    private BocciaModel _model;
 
     // Start is called before the first frame update
     void Start()
     {
         // cache model and subscribe for changed event
-        model = BocciaModel.Instance;
+        _model = BocciaModel.Instance;
+        _model.BciChanged += BciChanged;
 
         // connect buttons to model
         // Note - need to connect to real model function, start menu is just for test
-        trainingButton.onClick.AddListener(model.Train);
-        playBocciaButton.onClick.AddListener(model.ShowRampSetup);
-        virtualPlayButton.onClick.AddListener(model.VirtualPlay);
+        trainingButton.onClick.AddListener(_model.Train);
+        playBocciaButton.onClick.AddListener(_model.ShowRampSetup);
+        virtualPlayButton.onClick.AddListener(_model.VirtualPlay);
+
+        // Ensure Play Boccia and Virtual Play buttons cannot be clicked yet
+        playBocciaButton.interactable = false;
+        virtualPlayButton.interactable = false;
+    }
+
+    private void BciChanged()
+    {
+        // Turn on Play and Virtual Play buttons only when training is complete
+        if (_model.BciTrained == true)
+        {
+            playBocciaButton.interactable = true;
+            virtualPlayButton.interactable = true;
+        }
+
+        else 
+        {
+            playBocciaButton.interactable = false;
+            virtualPlayButton.interactable = false;
+        }
     }
 }

--- a/Boccia-Unity/Assets/Boccia/UI/PlayMenuPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayMenuPresenter.cs
@@ -25,23 +25,25 @@ public class PlayMenuPresenter : MonoBehaviour
         virtualPlayButton.onClick.AddListener(_model.VirtualPlay);
 
         // Ensure Play Boccia and Virtual Play buttons cannot be clicked yet
-        playBocciaButton.interactable = false;
-        virtualPlayButton.interactable = false;
+        // TODO: Uncomment this when done development
+        // playBocciaButton.interactable = false;
+        // virtualPlayButton.interactable = false;
     }
 
     private void BciChanged()
     {
         // Turn on Play and Virtual Play buttons only when training is complete
-        if (_model.BciTrained == true)
-        {
-            playBocciaButton.interactable = true;
-            virtualPlayButton.interactable = true;
-        }
+        // TODO: Uncomment this when done development
+        // if (_model.BciTrained == true)
+        // {
+        //     playBocciaButton.interactable = true;
+        //     virtualPlayButton.interactable = true;
+        // }
 
-        else 
-        {
-            playBocciaButton.interactable = false;
-            virtualPlayButton.interactable = false;
-        }
+        // else 
+        // {
+        //     playBocciaButton.interactable = false;
+        //     virtualPlayButton.interactable = false;
+        // }
     }
 }

--- a/Boccia-Unity/Assets/Boccia/UI/PlayMenuPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayMenuPresenter.cs
@@ -32,7 +32,6 @@ public class PlayMenuPresenter : MonoBehaviour
     private void BciChanged()
     {
         // Turn on Play and Virtual Play buttons only when training is complete
-        /*
         if (_model.BciTrained == true)
         {
             playBocciaButton.interactable = true;
@@ -44,6 +43,5 @@ public class PlayMenuPresenter : MonoBehaviour
             playBocciaButton.interactable = false;
             virtualPlayButton.interactable = false;
         }
-        */
     }
 }

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/PlayMenu.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/PlayMenu.prefab
@@ -372,7 +372,7 @@ MonoBehaviour:
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.39215687}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
@@ -493,7 +493,7 @@ MonoBehaviour:
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.39215687}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/PlayMenu.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/PlayMenu.prefab
@@ -372,7 +372,7 @@ MonoBehaviour:
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.39215687}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
@@ -493,7 +493,7 @@ MonoBehaviour:
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.39215687}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:


### PR DESCRIPTION
[BOC-66:](https://bci4kids.atlassian.net/browse/BOC-66?atlOrigin=eyJpIjoiODRlNjI0ZWUxYzBlNDVjYWExM2U2ZjRkZTc4YjVhYjEiLCJwIjoiaiJ9) The Play button and the Virtual Play button cannot be clicked until training is complete. 

Changes:
- In PlayMenuPresenter, the Play and Virtual Play buttons are set to non-interactable at Start().
- When training is complete, the BciTrained bool is set to true (from [PR #33](https://github.com/kirtonBCIlab/boccia-bci/pull/33))
- PlayMenuPresenter subscribes to the BciChanged event, and after BciTrained is set to True, it turns on the Play and Virtual Play buttons

Note: This PR should probably be merged with the code in PlayMenuPresenter commented out. Since we are still working on the Play and Virtual Play screens, it would be a bit inconvenient for us to have to sit through the training every time we run the game in order to move on to those screens. 