### PR TITLE
Fix the ball and fan interaction bug

### DIFF
--- a/Boccia-Unity/Assets/Boccia/Ramp/Ramp Prefabs/Large Boccia Ball.prefab
+++ b/Boccia-Unity/Assets/Boccia/Ramp/Ramp Prefabs/Large Boccia Ball.prefab
@@ -13,9 +13,9 @@ GameObject:
   - component: {fileID: 7697471108653858993}
   - component: {fileID: 7628221105401001540}
   - component: {fileID: 7489905980737200750}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: Large Boccia Ball
-  m_TagString: Untagged
+  m_TagString: BocciaBall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Boccia-Unity/Assets/Boccia/Ramp/Ramp Prefabs/Small Boccia Ball.prefab
+++ b/Boccia-Unity/Assets/Boccia/Ramp/Ramp Prefabs/Small Boccia Ball.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 514650632094599693}
   - component: {fileID: 6744055110612752849}
   - component: {fileID: 8996746463622245752}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: Small Boccia Ball
   m_TagString: BocciaBall
   m_Icon: {fileID: 0}

--- a/Boccia-Unity/ProjectSettings/DynamicsManager.asset
+++ b/Boccia-Unity/ProjectSettings/DynamicsManager.asset
@@ -3,10 +3,11 @@
 --- !u!55 &1
 PhysicsManager:
   m_ObjectHideFlags: 0
-  serializedVersion: 11
+  serializedVersion: 14
   m_Gravity: {x: 0, y: -9.81, z: 0}
   m_DefaultMaterial: {fileID: 0}
   m_BounceThreshold: 2
+  m_DefaultMaxDepenetrationVelocity: 10
   m_SleepThreshold: 0.005
   m_DefaultContactOffset: 0.01
   m_DefaultSolverIterations: 6
@@ -17,11 +18,13 @@ PhysicsManager:
   m_ClothInterCollisionDistance: 0
   m_ClothInterCollisionStiffness: 0
   m_ContactsGeneration: 1
-  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-  m_AutoSimulation: 1
+  m_LayerCollisionMatrix: ffffffffffffffffffffffff7ffffffffffffffffffffffffffffffff7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_SimulationMode: 0
   m_AutoSyncTransforms: 0
   m_ReuseCollisionCallbacks: 1
+  m_InvokeCollisionCallbacks: 1
   m_ClothInterCollisionSettingsToggle: 0
+  m_ClothGravity: {x: 0, y: -9.81, z: 0}
   m_ContactPairsMode: 0
   m_BroadphaseType: 0
   m_WorldBounds:
@@ -31,4 +34,6 @@ PhysicsManager:
   m_FrictionType: 0
   m_EnableEnhancedDeterminism: 0
   m_EnableUnifiedHeightmaps: 1
-  m_DefaultMaxAngluarSpeed: 7
+  m_ImprovedPatchFriction: 0
+  m_SolverType: 0
+  m_DefaultMaxAngularSpeed: 7

--- a/Boccia-Unity/ProjectSettings/TagManager.asset
+++ b/Boccia-Unity/ProjectSettings/TagManager.asset
@@ -18,7 +18,7 @@ TagManager:
   - Water
   - UI
   - VirtualPlayUI
-  - 
+  - Ball
   - 
   - 
   - 


### PR DESCRIPTION
[BOC-117](https://bci4kids.atlassian.net/browse/BOC-117?atlOrigin=eyJpIjoiYjAyZDU1ODc1NTZiNDJjY2I2MmJkYjQxZmU1NTgzOGUiLCJwIjoiaiJ9): Ball interacts with fan

The ball was interacting with the fan collider and rolling on top of the fan instead of the floor. 

- I added a new layer (Layer 7) for the balls, and applied it to the ball prefabs.
- The fan segments already were set to generate with the Interactable layer.
- In the Project Settings > Physics, I disabled the collision between the Ball layer and the Interactable layer in the Layer Collision Matrix, so that the two layers do not interact.
- Now, the ball doesn't collide with the fan, and instead passes through the fan to roll on the floor. The fan objects remain clickable.