### PR TITLE
101-create-hardwareRamp-controller

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanInteractions.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanInteractions.cs
@@ -110,7 +110,7 @@ public class FanInteractions : MonoBehaviour, IPointerClickHandler
 
     private void OnFanSegmentClick(int segmentID)
     {
-        Debug.Log($"Segment ID: {segmentID}");
+        // Debug.Log($"Segment ID: {segmentID}");
         int columnIndex = _fanSettings.NColumns - 1 - (segmentID / _fanSettings.NRows);
         int rowIndex = _fanSettings.NRows - 1 - (segmentID % _fanSettings.NRows);
 
@@ -138,12 +138,12 @@ public class FanInteractions : MonoBehaviour, IPointerClickHandler
         switch (_fanPresenter.positioningMode)
         {
             case FanPositioningMode.CenterToRails:
-                Debug.Log($"Relative Rotation: {rotationAngle}, Elevation: {elevation}");
+                // Debug.Log($"Relative Rotation: {rotationAngle}, Elevation: {elevation}");
                 _model.RotateBy(rotationAngle);
                 _model.ElevateBy(elevation);
                 break;
             case FanPositioningMode.CenterToBase:
-                Debug.Log($"Absolute Rotation: {rotationAngle}, Elevation: {elevation}");
+                // Debug.Log($"Absolute Rotation: {rotationAngle}, Elevation: {elevation}");
                 _model.RotateTo(rotationAngle);
                 _model.ElevateTo(elevation + 50f); // Add an offset of 50%, since 50% is the starting point of the elevation range
                 break;

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaData.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaData.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using System.IO.Ports;
 
 public enum BocciaBciParadigm
 {
@@ -58,8 +59,9 @@ public class BocciaData
 [System.Serializable]
 public class HardwareSettingsContainer
 {
-    public string SerialPort;
+    public string COMPort;
     public int BaudRate;
+    public SerialPort Serial; 
     public bool IsSerialPortConnected;
     public bool IsHardwareRampMoving;
     public Dictionary<string, bool> IsRampCalibrationDone = new();

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -63,19 +63,19 @@ public class BocciaModel : Singleton<BocciaModel>
     public event System.Action BallResetChanged;
 
     // Hardware interface
-    // TODO - create this based on game mode (live or sim)    
+    // TODO - create this based on game mode (live or sim)
     public void SetRampControllerBasedOnMode()
     {
         switch (GameMode)
         {
-            case BocciaGameMode.Play:
+            case BocciaGameMode.Play:  // Real ramp
                 rampController.RampChanged -= SendRampChangeEvent;
-                rampController = _hardwareRamp;                
+                rampController = _hardwareRamp;
                 rampController.RampChanged += SendRampChangeEvent;
                 break;
-            default:
+            default:  // Simulated ramp
                 rampController.RampChanged -= SendRampChangeEvent;
-                rampController = _simulatedRamp;                
+                rampController = _simulatedRamp;
                 rampController.RampChanged += SendRampChangeEvent;
                 break;     
         }   
@@ -107,7 +107,6 @@ public class BocciaModel : Singleton<BocciaModel>
 
         // Initialize controller to _simulatedRamp
         rampController = _simulatedRamp;
-        // SetRampControllerBasedOnMode();
 
         // Set default hardware options
         SetDefaultHardwareOptions();
@@ -122,10 +121,9 @@ public class BocciaModel : Singleton<BocciaModel>
     // This is triggered each time the application starts
     private void SetDefaultHardwareOptions()
     {
-
         bocciaData.HardwareSettings.COMPort = "";
         bocciaData.HardwareSettings.BaudRate = 9600;
-        bocciaData.HardwareSettings.Serial = null;
+        bocciaData.HardwareSettings.Serial = null;  // Need to have so that serial port connection to hardware persists even if we switch away from the hardware ramp
         bocciaData.HardwareSettings.IsHardwareRampMoving = false;
         bocciaData.HardwareSettings.IsSerialPortConnected = false;
         bocciaData.HardwareSettings.IsRampCalibrationDone = new Dictionary<string, bool>

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -63,7 +63,7 @@ public class BocciaModel : Singleton<BocciaModel>
     public event System.Action BallResetChanged;
 
     // Hardware interface
-    // TODO - create this based on game mode (live or sim)
+    // TODO - create this based on game mode (live or sim)    
     public void SetRampControllerBasedOnMode()
     {
         switch (GameMode)
@@ -123,8 +123,9 @@ public class BocciaModel : Singleton<BocciaModel>
     private void SetDefaultHardwareOptions()
     {
 
-        bocciaData.HardwareSettings.SerialPort = "";
+        bocciaData.HardwareSettings.COMPort = "";
         bocciaData.HardwareSettings.BaudRate = 9600;
+        bocciaData.HardwareSettings.Serial = null;
         bocciaData.HardwareSettings.IsHardwareRampMoving = false;
         bocciaData.HardwareSettings.IsSerialPortConnected = false;
         bocciaData.HardwareSettings.IsRampCalibrationDone = new Dictionary<string, bool>
@@ -482,8 +483,12 @@ public class BocciaModel : Singleton<BocciaModel>
 
     private void ResetRampHardwareState()
     {
+        if (bocciaData.HardwareSettings.Serial != null && bocciaData.HardwareSettings.Serial.IsOpen)
+        {
+            bocciaData.HardwareSettings.Serial.Close();
+        }
         bocciaData.HardwareSettings.IsSerialPortConnected = false;
-        bocciaData.HardwareSettings.SerialPort = "";
+        bocciaData.HardwareSettings.COMPort = "";
     }
 }
 

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -21,10 +21,16 @@ public class BocciaModel : Singleton<BocciaModel>
 
     // Game
     public BocciaGameMode GameMode;
+
+    private RampController _simulatedRamp = new SimulatedRamp();
+    private RampController _hardwareRamp = new HardwareRamp();
+    
+    private RampController rampController;
     public float RampRotation => rampController.Rotation;
     public float RampElevation => rampController.Elevation;
     public bool BarState => rampController.IsBarOpen;
     public bool IsRampMoving => rampController.IsMoving;
+    
     public BocciaBallState BallState;
 
     // Expose the GameOptionsContainer via a property
@@ -58,7 +64,22 @@ public class BocciaModel : Singleton<BocciaModel>
 
     // Hardware interface
     // TODO - create this based on game mode (live or sim)
-    private RampController rampController = new SimulatedRamp();
+    public void SetRampControllerBasedOnMode()
+    {
+        switch (GameMode)
+        {
+            case BocciaGameMode.Play:
+                rampController.RampChanged -= SendRampChangeEvent;
+                rampController = _hardwareRamp;                
+                rampController.RampChanged += SendRampChangeEvent;
+                break;
+            default:
+                rampController.RampChanged -= SendRampChangeEvent;
+                rampController = _simulatedRamp;                
+                rampController.RampChanged += SendRampChangeEvent;
+                break;     
+        }   
+    }
 
     public void Start()
     {
@@ -84,8 +105,9 @@ public class BocciaModel : Singleton<BocciaModel>
 
         SendRampChangeEvent();
 
-        // For now, just emit change event if ramp changes
-        rampController.RampChanged += SendRampChangeEvent;
+        // Initialize controller to _simulatedRamp
+        rampController = _simulatedRamp;
+        // SetRampControllerBasedOnMode();
 
         // Set default hardware options
         SetDefaultHardwareOptions();
@@ -249,33 +271,33 @@ public class BocciaModel : Singleton<BocciaModel>
     // MARK: Navigation control
     public void StartMenu()
     {
+        GameMode = BocciaGameMode.StopPlay;
         ShowScreen(BocciaScreen.StartMenu);
-        // GameMode = BocciaGameMode.Stop;
     }
 
     public void PlayMenu()
     {
+        GameMode = BocciaGameMode.StopPlay;
         ShowScreen(BocciaScreen.PlayMenu);
-        // GameMode = BocciaGameMode.Stop;
     }
 
     public void Train()
     {
+        GameMode = BocciaGameMode.Train;
         ShowScreen(BocciaScreen.TrainingScreen);
         // start training, hamburger -> menu = stop?
-        // GameMode = BocciaGameMode.Train;
     }
 
     public void Play()
     {
+        GameMode = BocciaGameMode.Play;
         ShowScreen(BocciaScreen.Play);
-        // GameMode = BocciaGameMode.Play;
     }
 
     public void VirtualPlay()
     {
+        GameMode = BocciaGameMode.Virtual;
         ShowScreen(BocciaScreen.VirtualPlay);
-        // GameMode = BocciaGameMode.Virtual;
     }
 
     public void ShowHamburgerMenu()

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Ports;
+using UnityEngine;
+
+public class HardwareRamp : RampController
+{
+    public event Action RampChanged;
+
+    public float Rotation { get; private set; }
+    public float Elevation { get; private set; }
+    public bool IsBarOpen { get; private set;}
+    public bool IsMoving { get; set; }
+    
+    public string COMPort { get; private set; }
+    public int BaudRate { get; private set; }
+    
+    private SerialPort _serial;
+    public string SerialCommand { get; private set; }
+
+    public bool SerialEnabled { get; private set; }
+    
+    private List<string> _serialCommands;
+
+    public HardwareRamp()
+    {
+        Rotation = 0.0f;
+        Elevation = 50.0f;
+        IsBarOpen = false; // Initialize the bar state as closed
+        IsMoving = false;
+        SerialCommand = "";
+        _serialCommands = new List<string>();
+    }
+
+    public void RotateBy(float degrees)
+    {
+        Rotation += degrees;
+        _serialCommands.Add($"rr{degrees}");
+        // Debug.Log($"Hardware rote by: {Rotation}");
+        SendChangeEvent();
+    }
+
+    public void RotateTo(float degrees)
+    {
+        Rotation = degrees;
+        _serialCommands.Add($"ra{degrees}");
+        // Debug.Log($"Hardware rote to: {Rotation}");
+        SendChangeEvent();
+    }
+
+    public void ElevateBy(float elevation)
+    {
+        Elevation += elevation;
+        _serialCommands.Add($"er{elevation}");
+        // Debug.Log($"Hardware elevate by: {Elevation}");
+        SendChangeEvent();
+    }
+
+    public void ElevateTo(float elevation)
+    {
+        Elevation = elevation;
+        _serialCommands.Add($"ea{elevation}");
+        Debug.Log($"Hardware elevate to: {Elevation}");
+        SendChangeEvent();
+    }
+
+    public void ResetRampPosition()
+    {
+        Rotation = 0.0f;
+        Elevation = 50.0f;
+        _serialCommands.Add("ra0");
+        _serialCommands.Add("ea50");
+        SendChangeEvent();
+    }
+
+    public void DropBall()
+    {
+        IsBarOpen = true; // Toggle bar state
+        _serialCommands.Add("dd-70");
+        SendChangeEvent();
+    }
+
+    public void ResetBar()
+    {
+        IsBarOpen = false;
+        SendChangeEvent();
+    }
+
+    public void ConnectToSerialPort()
+    {
+        try      
+        {
+            _serial = new SerialPort(COMPort, BaudRate)
+            {
+                Encoding = System.Text.Encoding.UTF8,
+                DtrEnable = true
+            };
+            
+            _serial.Open();
+            // Debug.Log("Connected to port: " + COMPort);
+            
+            SerialEnabled = true;
+        }
+
+        catch (Exception ex)
+        {
+            Debug.Log(ex.Message);
+            SerialEnabled = false;
+        }
+    }
+
+    public void DisconnectFromSerialPort()
+    {
+        if (_serial != null && _serial.IsOpen)
+        {
+            _serial.Close();
+            // Debug.Log("Disconnected from port: " + COMPort);
+        }
+    }
+
+    private void SendChangeEvent()
+    {
+        RampChanged?.Invoke();
+    }
+
+    public void sendSerialCommand()
+    {
+        SerialCommand = string.Join(">", _serialCommands);
+
+        if (_serial != null && _serial.IsOpen)
+        {
+            _serial.WriteLine(SerialCommand);
+            _serialCommands.Clear();
+        }
+    }
+}

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs.meta
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 34f0058273174e0489025a02344cc273
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boccia-Unity/Assets/Boccia/Model/SimulatedRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/SimulatedRamp.cs
@@ -22,31 +22,34 @@ public class SimulatedRamp : RampController
         Rotation = 0.0f;
         Elevation = 50.0f;
         IsBarOpen = false; // Initialize the bar state as closed
+        IsMoving = false;
     }
 
     public void RotateBy(float degrees)
     {
         Rotation += degrees;
-        //Debug.Log($"Rotation: {Rotation}");
+        // Debug.Log($"Simulated rotation by: {Rotation}");
         SendChangeEvent();
     }
 
     public void RotateTo(float degrees)
     {
         Rotation = degrees;
+        // Debug.Log($"Simulated rotation to: {Rotation}");
         SendChangeEvent();
     }
 
     public void ElevateBy(float elevation)
     {
         Elevation += elevation;
-        //Debug.Log($"Elevation: {Elevation}");
+        //Debug.Log($"Simulated elevation by: {Elevation}");
         SendChangeEvent();
     }
 
     public void ElevateTo(float elevation)
     {
         Elevation = elevation;
+        // Debug.Log($"Simulated elevation to: {Elevation}");
         SendChangeEvent();
     }
 

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -13,8 +13,7 @@ public class PlayScreenPresenter : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        _model = BocciaModel.Instance;
-        _model.WasChanged += ModelChanged;
+        // _model = BocciaModel.Instance;
 
         // connect buttons to model
         resetRampButton.onClick.AddListener(_model.ResetRampPosition);
@@ -25,6 +24,20 @@ public class PlayScreenPresenter : MonoBehaviour
     void Update()
     {
         
+    }
+
+    void OnEnable()
+    {
+        if (_model == null)
+        {
+            _model = BocciaModel.Instance;
+        }
+        _model.WasChanged += ModelChanged;
+    }
+
+    void OnDisable()
+    {
+        _model.WasChanged -= ModelChanged;
     }
 
     private void ModelChanged()

--- a/Boccia-Unity/Assets/Boccia/UI/ScreenSwitcher.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/ScreenSwitcher.cs
@@ -105,6 +105,9 @@ public class ScreenSwitcher : MonoBehaviour
                 PanCameraToScreen(StartMenu, CameraDistance);
                 break;
         }
+
+        // Maybe this call is expensive, could look into calling only on the appropriate screens
+        model.SetRampControllerBasedOnMode();
     }
 
     // Pans the camera to show the new screen, hides all others


### PR DESCRIPTION
There are a `simulatedRamp`and  `hardwareRamp` controllers now.
The active controller (i.e., simulated vs hardware) should be set to `rampController` according to the appropriate screen.
- Play screen: hardware controller
- Virtual play or training screen: simulated controller

You can check the proper model is selected by adding breakpoints for debugging, or uncommenting the debug calls in RotateTo, RotateBy, ElevateTo, ElevateByin the simulatedRamp and hardwareRamp scripts.
