### PR TITLE
Fix court view bug

### DIFF
--- a/Boccia-Unity/Assets/Boccia/World/VirtualPlayCamera.prefab
+++ b/Boccia-Unity/Assets/Boccia/World/VirtualPlayCamera.prefab
@@ -72,7 +72,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 55
+    m_Bits: 183
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0


### PR DESCRIPTION
[BOC-132](https://bci4kids.atlassian.net/browse/BOC-132?atlOrigin=eyJpIjoiZDViNGExYzU3MWU4NDc0MmIxNmQyNWVkMzJkOWNhOTUiLCJwIjoiaiJ9)

The court view camera wasn't displaying the balls anymore after I set them to a different layer in PR #43. 

This PR is to edit the Culling Mask setting on the VirtualPlayCamera to include the Ball layer. 