### PR TITLE
Fix ball instantiation bug

### DIFF
--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -194,6 +194,16 @@ public class BocciaModel : Singleton<BocciaModel>
         SendRampChangeEvent();
     }
 
+    public void SetBallStateReady()
+    {
+        BallState = BocciaBallState.Ready;
+    }
+
+    public void SetBallStateReleased()
+    {
+        BallState = BocciaBallState.Released;
+    }
+
     public void ResetVirtualBalls()
     {
         SendBallResetEvent();

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -25,6 +25,7 @@ public class BallPresenter : MonoBehaviour
     // Coroutines
     private Coroutine _barCoroutine;
     private Coroutine _checkBallCoroutine;
+    private Coroutine _ballResetCoroutine;
 
     // Flags
     private bool _firstBallDropped = false; // To check if at least one ball has been dropped
@@ -156,7 +157,7 @@ public class BallPresenter : MonoBehaviour
         _ballRigidbody.velocity = Vector3.zero;
         _ballRigidbody.angularVelocity = Vector3.zero;
 
-        // Do not instantiate a new ball unless the bar is currently closed
+        // If the bar is NOT closed, wait before creating a new ball
         while (!IsBarClosed())
         {
             yield return null;
@@ -208,7 +209,19 @@ public class BallPresenter : MonoBehaviour
         _ballCount = 0;
         _firstBallDropped = false;
 
-        // Create a new active ball
+        // Call the method to create a new ball
+        StartCoroutine(BallResetCoroutine());
+    }
+
+    private IEnumerator BallResetCoroutine()
+    {
+        // If the bar is NOT closed, wait before creating a new ball
+        while (!IsBarClosed())
+        {
+            yield return null;
+        }
+
+        // Create a new ball
         NewBocciaBall();
 
         // Remove the old boccia balls

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -108,14 +108,20 @@ public class BallPresenter : MonoBehaviour
     private IEnumerator BarAnimation()
     {
         _model.SetRampMoving(true);
+
         // Bar opening and closing animation
         _barAnimation.SetBool("isOpening", true);
         yield return new WaitForSecondsRealtime(1f);
         _barAnimation.SetBool("isOpening", false);
-        _model.ResetBar(); // Call the method to reset the bar state to false
+
+        // Call the method to reset the Model's bar state
+        _model.ResetBar();
+
+        // Wait for the bar to fully close
+        yield return new WaitForSecondsRealtime(3f);
+        _model.SetRampMoving(false);
 
         yield return null;
-        _model.SetRampMoving(false);
     }
 
     private IEnumerator CheckBallSpeed()

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -79,17 +79,23 @@ public class BallPresenter : MonoBehaviour
         // If model.BarState is true, it means the bar opened (drop ball was pressed)
         if (_model.BarState)
         {
-            // Convert ball position and rotation to local space of elevationPlate
-            _dropPosition = elevationPlate.transform.InverseTransformPoint(_activeBall.transform.position);
-            _dropRotation = Quaternion.Inverse(elevationPlate.transform.rotation) * _activeBall.transform.rotation;
-
-            // Toggle the ball drop flag
-            _firstBallDropped = true;
-
             // Start the bar movement animation
             _dropBallCoroutine = StartCoroutine(DropBall());
 
-            _checkBallCoroutine = StartCoroutine(CheckBallSpeed());
+            if (_model.BallState == BocciaBallState.Ready)
+            {
+                // Convert ball position and rotation to local space of elevationPlate
+                _dropPosition = elevationPlate.transform.InverseTransformPoint(_activeBall.transform.position);
+                _dropRotation = Quaternion.Inverse(elevationPlate.transform.rotation) * _activeBall.transform.rotation;
+
+                // Toggle the ball drop flag
+                _firstBallDropped = true;
+
+                _checkBallCoroutine = StartCoroutine(CheckBallSpeed());
+
+                // Set the ball state to released
+                _model.SetBallStateReleased();
+            }
         }
     }
 
@@ -142,6 +148,9 @@ public class BallPresenter : MonoBehaviour
         // Instantiate the new ball
         _activeBall = Instantiate(ball, newBallPosition, newBallRotation, transform);
         InitializeBall();
+
+        // Set the ball state to ready
+        _model.SetBallStateReady();
     }
 
     private void ResetBocciaBalls()

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -4,23 +4,29 @@ using UnityEngine;
 
 public class BallPresenter : MonoBehaviour
 {
+    // Model reference
+    private BocciaModel _model;
+
+    // References for the Boccia balls
     public GameObject ball; // The ball prefab
     private GameObject _activeBall; // Refers the the ball currently in use for each shot
     private int _ballCount = 0;
     private Rigidbody _ballRigidbody;
 
+    // References for the bar and elevation mechanism
     private Animator _barAnimation;
     public GameObject dropBar;
     public GameObject elevationPlate;
 
-    private BocciaModel _model;
-
+    // Variables for storing the ball transform
     private Vector3 _dropPosition;
     private Quaternion _dropRotation;
 
+    // Coroutines
     private Coroutine _barCoroutine;
     private Coroutine _checkBallCoroutine;
 
+    // Flags
     private bool _firstBallDropped = false; // To check if at least one ball has been dropped
 
     // Start is called before the first frame update
@@ -28,7 +34,7 @@ public class BallPresenter : MonoBehaviour
     {
         // cache model and subscribe for changed event
         _model = BocciaModel.Instance;
-        _model.WasChanged += RampChanged;
+        _model.WasChanged += ModelChanged;
         _model.BallResetChanged += ResetBocciaBalls;
 
         // Initialize ball
@@ -38,19 +44,19 @@ public class BallPresenter : MonoBehaviour
         // Initialize bar animation
         _barAnimation = dropBar.GetComponent<Animator>();
 
-        // initialize to saved data
-        RampChanged();
+        // Initialize to saved data
+        ModelChanged();
     }
 
     void OnDisable()
     {
-        _model.WasChanged -= RampChanged;
+        _model.WasChanged -= ModelChanged;
         _model.BallResetChanged -= ResetBocciaBalls;
     }
 
     private void InitializeBall()
     {
-        // Make sure the ball is enabled
+        // Make sure the ball objectis enabled
         if (!_activeBall.activeSelf)
         {
             _activeBall.SetActive(true);
@@ -67,21 +73,22 @@ public class BallPresenter : MonoBehaviour
         // Name the ball GameObject in the hierarchy
         _activeBall.name = "Ball " + _ballCount;
 
-        // Make sure its the right color
+        // Make sure it is the right color
         _activeBall.GetComponent<Renderer>().material.color = _model.GameOptions.BallColor;
     }
 
-    private void RampChanged()
+    private void ModelChanged()
     {
-        // Updates color if ball color is pressed
+        // Updates color if ball color button is pressed
         _activeBall.GetComponent<Renderer>().material.color = _model.GameOptions.BallColor;
 
-        // If model.BarState is true, it means the bar opened (drop ball was pressed)
+        // If model.BarState is true, it means the bar opened (drop ball button was pressed)
         if (_model.BarState)
         {
             // Start the bar movement animation
             _barCoroutine = StartCoroutine(BarAnimation());
 
+            // Only execute the ball drop code if the Model's ball state is Ready
             if (_model.BallState == BocciaBallState.Ready)
             {
                 DropBall();
@@ -163,7 +170,6 @@ public class BallPresenter : MonoBehaviour
         {
             StopActiveCoroutines();
         } 
-
 
         // Create a new ball at the previous ball's drop position and rotation
         // Convert the drop position and rotation back into to world space

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -84,19 +84,25 @@ public class BallPresenter : MonoBehaviour
 
             if (_model.BallState == BocciaBallState.Ready)
             {
-                // Convert ball position and rotation to local space of elevationPlate
-                _dropPosition = elevationPlate.transform.InverseTransformPoint(_activeBall.transform.position);
-                _dropRotation = Quaternion.Inverse(elevationPlate.transform.rotation) * _activeBall.transform.rotation;
-
-                // Toggle the ball drop flag
-                _firstBallDropped = true;
-
-                _checkBallCoroutine = StartCoroutine(CheckBallSpeed());
-
-                // Set the ball state to released
-                _model.SetBallStateReleased();
+                DropBall();
             }
         }
+    }
+
+    private void DropBall()
+    {
+        // Convert ball position and rotation to local space of elevationPlate
+        _dropPosition = elevationPlate.transform.InverseTransformPoint(_activeBall.transform.position);
+        _dropRotation = Quaternion.Inverse(elevationPlate.transform.rotation) * _activeBall.transform.rotation;
+
+        // Set the ball state to released
+        _model.SetBallStateReleased();
+
+        // Start the coroutine to check the ball speed
+        _checkBallCoroutine = StartCoroutine(CheckBallSpeed());
+
+        // Toggle the ball drop flag
+        _firstBallDropped = true;
     }
 
     private IEnumerator BarAnimation()

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -158,12 +158,12 @@ public class BallPresenter : MonoBehaviour
 
     private void NewBocciaBall()
     {
-        // Make sure the CheckBallSpeed coroutine is stopped
-        if (_checkBallCoroutine != null)
+        // Stop the coroutines if they are running
+        if (_barCoroutine != null && _checkBallCoroutine != null)
         {
-            StopCoroutine(_checkBallCoroutine);
-            _checkBallCoroutine = null;
-        }
+            StopActiveCoroutines();
+        } 
+
 
         // Create a new ball at the previous ball's drop position and rotation
         // Convert the drop position and rotation back into to world space
@@ -188,17 +188,10 @@ public class BallPresenter : MonoBehaviour
         }
 
         // Stop the coroutines if they are running
-        if (_barCoroutine != null)
+        if (_barCoroutine != null && _checkBallCoroutine != null)
         {
-            StopCoroutine(_barCoroutine);
-            _barCoroutine = null;
-        }
-
-        if (_checkBallCoroutine != null) 
-        {
-            StopCoroutine(_checkBallCoroutine);
-            _checkBallCoroutine = null;
-        }
+            StopActiveCoroutines();
+        } 
 
         // Reset ball count and first drop flag
         _ballCount = 0;
@@ -215,6 +208,15 @@ public class BallPresenter : MonoBehaviour
                 Destroy(child.gameObject);
             }
         }
+    }
+
+    private void StopActiveCoroutines()
+    {
+        StopCoroutine(_barCoroutine);
+        _barCoroutine = null;
+
+        StopCoroutine(_checkBallCoroutine);
+        _checkBallCoroutine = null;
     }
 
     /*

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -82,7 +82,7 @@ public class BallPresenter : MonoBehaviour
         // Updates color if ball color button is pressed
         _activeBall.GetComponent<Renderer>().material.color = _model.GameOptions.BallColor;
 
-        // If model.BarState is true, it means the bar opened (drop ball button was pressed)
+        // If model.BarState is true, it means the drop ball button was pressed
         if (_model.BarState)
         {
             // Start the bar movement animation
@@ -91,6 +91,8 @@ public class BallPresenter : MonoBehaviour
             // Only execute the ball drop code if the Model's ball state is Ready
             if (_model.BallState == BocciaBallState.Ready)
             {
+                // Call the method to log the drop position and rotation
+                // and the rest of the ball drop code
                 DropBall();
             }
         }
@@ -126,6 +128,7 @@ public class BallPresenter : MonoBehaviour
         _model.ResetBar();
 
         // Wait for the bar to fully close
+        // Before setting the ramp to not moving
         yield return new WaitForSecondsRealtime(3f);
         _model.SetRampMoving(false);
 

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -14,18 +14,16 @@ public class BallPresenter : MonoBehaviour
     private Rigidbody _ballRigidbody;
 
     // References for the bar and elevation mechanism
-    private Animator _barAnimation;
     public GameObject dropBar;
     public GameObject elevationPlate;
+    private Animator _barAnimation;
 
     // Variables for storing the ball transform
     private Vector3 _dropPosition;
     private Quaternion _dropRotation;
 
     // Coroutines
-    private Coroutine _barCoroutine;
     private Coroutine _checkBallCoroutine;
-    private Coroutine _ballResetCoroutine;
 
     // Flags
     private bool _firstBallDropped = false; // To check if at least one ball has been dropped
@@ -91,7 +89,7 @@ public class BallPresenter : MonoBehaviour
         if (_model.BarState)
         {
             // Start the bar movement animation
-            _barCoroutine = StartCoroutine(BarAnimation());
+            StartCoroutine(BarAnimation());
 
             // Only execute the ball drop code if the Model's ball state is Ready
             if (_model.BallState == BocciaBallState.Ready)

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -18,7 +18,7 @@ public class BallPresenter : MonoBehaviour
     private Vector3 _dropPosition;
     private Quaternion _dropRotation;
 
-    private Coroutine _dropBallCoroutine;
+    private Coroutine _barCoroutine;
     private Coroutine _checkBallCoroutine;
 
     private bool _firstBallDropped = false; // To check if at least one ball has been dropped
@@ -80,7 +80,7 @@ public class BallPresenter : MonoBehaviour
         if (_model.BarState)
         {
             // Start the bar movement animation
-            _dropBallCoroutine = StartCoroutine(DropBall());
+            _barCoroutine = StartCoroutine(BarAnimation());
 
             if (_model.BallState == BocciaBallState.Ready)
             {
@@ -99,7 +99,7 @@ public class BallPresenter : MonoBehaviour
         }
     }
 
-    private IEnumerator DropBall()
+    private IEnumerator BarAnimation()
     {
         _model.SetRampMoving(true);
         // Bar opening and closing animation
@@ -163,10 +163,10 @@ public class BallPresenter : MonoBehaviour
         }
 
         // Stop the coroutines if they are running
-        if (_dropBallCoroutine != null)
+        if (_barCoroutine != null)
         {
-            StopCoroutine(_dropBallCoroutine);
-            _dropBallCoroutine = null;
+            StopCoroutine(_barCoroutine);
+            _barCoroutine = null;
         }
 
         if (_checkBallCoroutine != null) 

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -30,6 +30,8 @@ public class BallPresenter : MonoBehaviour
     // Flags
     private bool _firstBallDropped = false; // To check if at least one ball has been dropped
 
+    
+    // MARK: Initialization
     // Start is called before the first frame update
     void Start()
     {
@@ -78,6 +80,8 @@ public class BallPresenter : MonoBehaviour
         _activeBall.GetComponent<Renderer>().material.color = _model.GameOptions.BallColor;
     }
 
+
+    // MARK: Model event handler
     private void ModelChanged()
     {
         // Updates color if ball color button is pressed
@@ -99,22 +103,7 @@ public class BallPresenter : MonoBehaviour
         }
     }
 
-    private void DropBall()
-    {
-        // Convert ball position and rotation to local space of elevationPlate
-        _dropPosition = elevationPlate.transform.InverseTransformPoint(_activeBall.transform.position);
-        _dropRotation = Quaternion.Inverse(elevationPlate.transform.rotation) * _activeBall.transform.rotation;
-
-        // Set the ball state to released
-        _model.SetBallStateReleased();
-
-        // Start the coroutine to check the ball speed
-        _checkBallCoroutine = StartCoroutine(CheckBallSpeed());
-
-        // Toggle the ball drop flag
-        _firstBallDropped = true;
-    }
-
+    // MARK: Bar Animation
     private IEnumerator BarAnimation()
     {
         _model.SetRampMoving(true);
@@ -142,6 +131,24 @@ public class BallPresenter : MonoBehaviour
         return _barAnimation.GetCurrentAnimatorStateInfo(0).IsName("DropBarClosed");
     }
 
+    
+    // MARK: Ball Drop
+    private void DropBall()
+    {
+        // Convert ball position and rotation to local space of elevationPlate
+        _dropPosition = elevationPlate.transform.InverseTransformPoint(_activeBall.transform.position);
+        _dropRotation = Quaternion.Inverse(elevationPlate.transform.rotation) * _activeBall.transform.rotation;
+
+        // Set the ball state to released
+        _model.SetBallStateReleased();
+
+        // Start the coroutine to check the ball speed
+        _checkBallCoroutine = StartCoroutine(CheckBallSpeed());
+
+        // Toggle the ball drop flag
+        _firstBallDropped = true;
+    }
+
     private IEnumerator CheckBallSpeed()
     {
         // Wait a bit for the ball to fully get rolling
@@ -167,6 +174,8 @@ public class BallPresenter : MonoBehaviour
         NewBocciaBall();
     }
 
+
+    // MARK: Ball Instantiation
     private void NewBocciaBall()
     {
         // Stop the check ball coroutine if it is running
@@ -189,6 +198,8 @@ public class BallPresenter : MonoBehaviour
         _model.SetBallStateReady();
     }
 
+    
+    // MARK: Virtual Play Ball Reset
     private void ResetBocciaBalls()
     {
         // Check if at least one ball has been dropped

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -115,6 +115,7 @@ public class BallPresenter : MonoBehaviour
         _barAnimation.SetBool("isOpening", false);
 
         // Call the method to reset the Model's bar state
+        // This is different from the states in the animator
         _model.ResetBar();
 
         // Wait for the bar to fully close
@@ -122,6 +123,12 @@ public class BallPresenter : MonoBehaviour
         _model.SetRampMoving(false);
 
         yield return null;
+    }
+
+    private bool IsBarClosed()
+    {
+        // Bool to check if the animation is complete
+        return _barAnimation.GetCurrentAnimatorStateInfo(0).IsName("DropBarClosed");
     }
 
     private IEnumerator CheckBallSpeed()
@@ -138,6 +145,12 @@ public class BallPresenter : MonoBehaviour
         // Stop the ball
         _ballRigidbody.velocity = Vector3.zero;
         _ballRigidbody.angularVelocity = Vector3.zero;
+
+        // Do not instantiate a new ball unless the bar is currently closed
+        while (!IsBarClosed())
+        {
+            yield return null;
+        }
 
         // Create a new ball
         NewBocciaBall();

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -79,16 +79,17 @@ public class BallPresenter : MonoBehaviour
         // If model.BarState is true, it means the bar opened (drop ball was pressed)
         if (_model.BarState)
         {
-            // Save ball position and rotation right before it is dropped
-            //dropPosition = activeBall.transform.position; 
-            //dropRotation = activeBall.transform.rotation;
-
             // Convert ball position and rotation to local space of elevationPlate
             _dropPosition = elevationPlate.transform.InverseTransformPoint(_activeBall.transform.position);
             _dropRotation = Quaternion.Inverse(elevationPlate.transform.rotation) * _activeBall.transform.rotation;
 
+            // Toggle the ball drop flag
+            _firstBallDropped = true;
+
             // Start the bar movement animation
-            StartCoroutine(DropBall());
+            _dropBallCoroutine = StartCoroutine(DropBall());
+
+            _checkBallCoroutine = StartCoroutine(CheckBallSpeed());
         }
     }
 
@@ -101,19 +102,15 @@ public class BallPresenter : MonoBehaviour
         _barAnimation.SetBool("isOpening", false);
         _model.ResetBar(); // Call the method to reset the bar state to false
 
-        // Wait to check speed of ball to avoid NewBocciaBall() happening too early
-        yield return new WaitForSecondsRealtime(1f); 
-        _checkBallCoroutine = StartCoroutine(CheckBallSpeed());
-
-        // Toggle the ball drop flag
-        _firstBallDropped = true;
-
         yield return null;
         _model.SetRampMoving(false);
     }
 
     private IEnumerator CheckBallSpeed()
     {
+        // Wait a bit for the ball to fully get rolling
+        yield return new WaitForSecondsRealtime(3f);
+
         // Velocity threshold
         while (_ballRigidbody.velocity.magnitude > 0.01f)
         {

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -165,10 +165,11 @@ public class BallPresenter : MonoBehaviour
 
     private void NewBocciaBall()
     {
-        // Stop the coroutines if they are running
-        if (_barCoroutine != null && _checkBallCoroutine != null)
+        // Stop the check ball coroutine if it is running
+        if (_checkBallCoroutine != null)
         {
-            StopActiveCoroutines();
+            StopCoroutine(_checkBallCoroutine);
+            _checkBallCoroutine = null;
         } 
 
         // Create a new ball at the previous ball's drop position and rotation
@@ -193,10 +194,11 @@ public class BallPresenter : MonoBehaviour
             return;
         }
 
-        // Stop the coroutines if they are running
-        if (_barCoroutine != null && _checkBallCoroutine != null)
+        // Stop the check ball coroutine if it is running
+        if (_checkBallCoroutine != null)
         {
-            StopActiveCoroutines();
+            StopCoroutine(_checkBallCoroutine);
+            _checkBallCoroutine = null;
         } 
 
         // Reset ball count and first drop flag
@@ -214,15 +216,6 @@ public class BallPresenter : MonoBehaviour
                 Destroy(child.gameObject);
             }
         }
-    }
-
-    private void StopActiveCoroutines()
-    {
-        StopCoroutine(_barCoroutine);
-        _barCoroutine = null;
-
-        StopCoroutine(_checkBallCoroutine);
-        _checkBallCoroutine = null;
     }
 
     /*


### PR DESCRIPTION
[BOC-120](https://bci4kids.atlassian.net/browse/BOC-120?atlOrigin=eyJpIjoiY2FlN2IwZGEwNDZkNDczMDljMTdmN2NkYjZjNjc5YTAiLCJwIjoiaiJ9): New ball instantiation bug - If the drop button is pressed when a ball is still rolling, the new ball is instantiated at the position of the rolling ball instead of the correct position in the ramp

To fix the bug:
- I added methods to the model to set the value of the BocciaBallState enum (this was already in BocciaTypes). I decided to use the "Ready" state when there is a ball sitting on the ramp, ready to be dropped. The "Released" state means the ball has been dropped and is currently rolling, and there is no ball on the ramp. 
- I modified BallPresenter so that the ball's drop position and rotation is only updated if the BallState in the model is currently set to "Ready," i.e. it only saves the pre-drop transform if there is actually a ball ready to be dropped. 
- After saving the ball's drop transform, BallPresenter calls the model method to set BallState to "Released". 
- I separated the bar animation code from the ball drop code, so when the Drop Button is pressed, the bar will still open and close. But as long as BallState is "Released", the drop ball logic will not be executed. 
- BallPresenter's NewBocciaBall() method calls the model method to set BallState back to "Ready" after a new ball is instantiated onto the ramp. 
- I also added logic so that the coroutines will wait for the bar to fully close (i.e. for the animator to reach the DropBarClosed state) before calling NewBocciaBall().

To test the changes: 

- Click the drop button in either Play or Virtual Play, and while the ball is still rolling, click the drop button at least one more time. When the ball comes to a stop, the new ball should instantiate properly onto the ramp. 
- In Virtual Play, click the Drop button and then click the Reset Balls button immediately after (while the bar is still open). You should see that it doesn't reset a new ball on the ramp until the bar is closed.


Note: Ball instantiation/reset still fails if the ball falls off the ramp (due to the ramp moving too quickly). That will be solved in [BOC-118](https://bci4kids.atlassian.net/browse/BOC-118?atlOrigin=eyJpIjoiY2NmOGRjN2E5YWU5NGIzOThkYjczMzVjMTVmOTg1ZmIiLCJwIjoiaiJ9).