### PR TITLE
Ball disappears after rolling in play mode

### DIFF
--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -28,6 +28,9 @@ public class BallPresenter : MonoBehaviour
     // Flags
     private bool _firstBallDropped = false; // To check if at least one ball has been dropped
 
+    // Game mode
+    private BocciaGameMode _gameMode;
+
     
     // MARK: Initialization
     // Start is called before the first frame update
@@ -48,6 +51,9 @@ public class BallPresenter : MonoBehaviour
 
         // Initialize to saved data
         ModelChanged();
+
+        // Initialize gameMode
+        _gameMode = _model.GameMode;
     }
 
     void OnDisable()
@@ -253,15 +259,11 @@ public class BallPresenter : MonoBehaviour
 
     private void NavigationChanged()
     {
-        // When the game switches to Play screen, reset balls
-        if (_model.CurrentScreen == BocciaScreen.Play)
+        // Reset balls every time the game mode is changed
+        BocciaGameMode currentGameMode = _model.GameMode;
+        if (currentGameMode != _gameMode)
         {
-            ResetBocciaBalls();
-        }
-
-        // When the game switches to Virtual Play screen, reset balls
-        if (_model.CurrentScreen == BocciaScreen.VirtualPlay)
-        {
+            _gameMode = currentGameMode;
             ResetBocciaBalls();
         }
     }

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -201,6 +201,12 @@ public class BallPresenter : MonoBehaviour
         {
             ResetBocciaBalls();
         }
+
+        // When the game switches to Virtual Play screen, reset balls
+        if (_model.CurrentScreen == BocciaScreen.VirtualPlay)
+        {
+            ResetBocciaBalls();
+        }
     }
 
     /*

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -29,6 +29,7 @@ public class BallPresenter : MonoBehaviour
         // cache model and subscribe for changed event
         _model = BocciaModel.Instance;
         _model.WasChanged += RampChanged;
+        _model.NavigationChanged += NavigationChanged;
         _model.BallResetChanged += ResetBocciaBalls;
 
         // Initialize ball
@@ -190,6 +191,15 @@ public class BallPresenter : MonoBehaviour
             {
                 Destroy(child.gameObject);
             }
+        }
+    }
+
+    private void NavigationChanged()
+    {
+        // When the game switches to Play screen, reset balls
+        if (_model.CurrentScreen == BocciaScreen.Play)
+        {
+            ResetBocciaBalls();
         }
     }
 

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -142,6 +142,13 @@ public class BallPresenter : MonoBehaviour
         Vector3 newBallPosition = elevationPlate.transform.TransformPoint(_dropPosition);
         Quaternion newBallRotation = elevationPlate.transform.rotation * _dropRotation;
 
+        // If this is Play mode, remove the previous ball
+        if (_model.GameMode == BocciaGameMode.Play)
+        {
+            GameObject previousBall = _activeBall;
+            Destroy(previousBall);
+        }
+
         // Instantiate the new ball
         _activeBall = Instantiate(ball, newBallPosition, newBallRotation, transform);
         InitializeBall();


### PR DESCRIPTION
[BOC-89](https://bci4kids.atlassian.net/browse/BOC-89?atlOrigin=eyJpIjoiMGM3YzliYTJjOGE5NDJkMzhmNWVlZWZlNDZiZjZiNjMiLCJwIjoiaiJ9)

In Play Mode, each ball should disappear from the scene after rolling. 

Changes:
- If the current GameMode is Play, the NewBocciaBall() method in `BallPresenter.cs` removes the previous ball from the scene after it stops rolling.
- `BallPresenter.cs` removes all balls currently on the court when entering the Play screen.
- The balls are reset when entering the Virtual Play screen (to reset the BallCount).