### PR TITLE
BOC124 – RampPresenter pulls rotation and elevation speeds from BocciaModel

### DIFF
--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -150,12 +150,15 @@ public class BocciaModel : Singleton<BocciaModel>
             GameOptions.BallColor = Color.red;  // Fallback if dictionary is empty (shouldn't happen)
         }
 
+        // User values
         bocciaData.GameOptions.ElevationPrecision = 3.0f;
         bocciaData.GameOptions.ElevationRange = 20.0f;
-        bocciaData.GameOptions.ElevationSpeed = 0.0f;
         bocciaData.GameOptions.RotationPrecision = 3.0f;
         bocciaData.GameOptions.RotationRange = 20.0f;
-        bocciaData.GameOptions.RotationSpeed = 0.0f;
+
+        // Operator values
+        bocciaData.GameOptions.ElevationSpeed = 5.0f;
+        bocciaData.GameOptions.RotationSpeed = 5.0f;
 
         // Note: SendRampChangeEvent() trigged within ResetGameOptionsToDefaults();
     }

--- a/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
@@ -12,12 +12,13 @@ public class RampPresenter : MonoBehaviour
     public GameObject elevationMechanism; // Elevation Mechanism child component of Shaft and Ramp (the ramp parts that will change elevation in the visualization)
     public GameObject rampAdapter; // To define direction of movement for elevationMechanism
 
-    private BocciaModel _model;
-
-    [SerializeField] private float elevationSpeed;
-    [SerializeField] private float rotationSpeed;
     public float minElevation = 0.0026f; 
     public float maxElevation = 0.43f; 
+
+    private BocciaModel _model;
+
+    [SerializeField] private float _elevationSpeed;
+    [SerializeField] private float _rotationSpeed;
 
     private Vector3 elevationDirection; // Vector to define the direction of motion of the elevationMechanism visualization
 
@@ -48,8 +49,8 @@ public class RampPresenter : MonoBehaviour
         // from the UI, which triggers BocciaModel.SendRampChangeEvent(), which this method will respond to,
         // Then, this method will run any time the User changes these values, ensuring the
         // elevation and rotation speeds are kept in sync with the model
-        elevationSpeed = _model.GameOptions.ElevationSpeed;
-        rotationSpeed = _model.GameOptions.RotationSpeed;
+        _elevationSpeed = _model.GameOptions.ElevationSpeed;
+        _rotationSpeed = _model.GameOptions.RotationSpeed;
 
         // Ramp is a digital twin, so we just match visualization with model data
         //Debug.Log(model.RampRotation);
@@ -68,7 +69,7 @@ public class RampPresenter : MonoBehaviour
 
         while (Quaternion.Angle(currentRotation, targetQuaternion) > 0.01f)
         {
-            currentRotation = Quaternion.Lerp(currentRotation, targetQuaternion, rotationSpeed * Time.deltaTime);
+            currentRotation = Quaternion.Lerp(currentRotation, targetQuaternion, _rotationSpeed * Time.deltaTime);
             rotationShaft.transform.localRotation = currentRotation;
             yield return null;
         }
@@ -87,7 +88,7 @@ public class RampPresenter : MonoBehaviour
 
         while (Vector3.Distance(currentElevation, targetElevation) > 0.001f)
         {
-            currentElevation = Vector3.Lerp(currentElevation, targetElevation, elevationSpeed * Time.deltaTime);
+            currentElevation = Vector3.Lerp(currentElevation, targetElevation, _elevationSpeed * Time.deltaTime);
             elevationMechanism.transform.localPosition = currentElevation;
             yield return null;
         }

--- a/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
@@ -14,8 +14,8 @@ public class RampPresenter : MonoBehaviour
 
     private BocciaModel _model;
 
-    public float rotationSpeed = 5.0f;
-    public float elevationSpeed = 5.0f;
+    [SerializeField] private float elevationSpeed;
+    [SerializeField] private float rotationSpeed;
     public float minElevation = 0.0026f; 
     public float maxElevation = 0.43f; 
 
@@ -43,6 +43,14 @@ public class RampPresenter : MonoBehaviour
 
     private void ModelChanged()
     {
+        // Pull elevation and rotation speeds from _model
+        // As GameOptionsMenuPresenter uses BocciaModel.SetGameOption() to update model values
+        // from the UI, which triggers BocciaModel.SendRampChangeEvent(), which this method will respond to,
+        // Then, this method will run any time the User changes these values, ensuring the
+        // elevation and rotation speeds are kept in sync with the model
+        elevationSpeed = _model.GameOptions.ElevationSpeed;
+        rotationSpeed = _model.GameOptions.RotationSpeed;
+
         // Ramp is a digital twin, so we just match visualization with model data
         //Debug.Log(model.RampRotation);
         StartCoroutine(RotationVisualization());

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/GameOptionsMenu.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/GameOptionsMenu.prefab
@@ -18003,10 +18003,10 @@ MonoBehaviour:
   m_FillRect: {fileID: 2477273195012389994}
   m_HandleRect: {fileID: 6092222662226599349}
   m_Direction: 0
-  m_MinValue: 0
-  m_MaxValue: 1
-  m_WholeNumbers: 0
-  m_Value: 0
+  m_MinValue: 1
+  m_MaxValue: 20
+  m_WholeNumbers: 1
+  m_Value: 1
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -18093,10 +18093,10 @@ MonoBehaviour:
   m_FillRect: {fileID: 259470118614894169}
   m_HandleRect: {fileID: 2695175203650030251}
   m_Direction: 0
-  m_MinValue: 0
-  m_MaxValue: 1
-  m_WholeNumbers: 0
-  m_Value: 0
+  m_MinValue: 1
+  m_MaxValue: 20
+  m_WholeNumbers: 1
+  m_Value: 1
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []


### PR DESCRIPTION
[BOC124](https://bci4kids.atlassian.net/jira/software/c/projects/BOC/boards/11?selectedIssue=BOC-124)

Previously the rotation (5.0f) and elevation (5.0f) speed were hardcoded to a value within RampPresenter.cs, and did not update from any changes within BocciaModel.GameOptions.

Now, the `elevationSpeed` and `rotationSpeed` are synced with BocciaModel, and will update whenever these values are changed by the User. They are set as serialized private variables

The default values for these with BocciaModel.SetDefaultGameOptions() were both set to 5.0f, which was the value previously hardcoded within RampPresenter.cs

I have also temporarily set the limits of elevation and rotation speed sliders in the GameOptionsMenu prefab as 1 to 20, as they were previously 0 to 1. I think these are going to be set programmatically in a future PR.

# Testing
- Load game, go to Game Options menu, change the value on elevation and rotation speed.
- Look at the changes being reflected in the `Boccia` object within the Boccia Scene. Select `Boccia` object in the Hierarchy, and within the Inspector look at the Elevation Speed and Rotation Speed values within Ramp Presenter script attached to Boccia object.
- Set ramp and elevation speed to max, go back to virtual play, watch things fly
- Go back to Game Options, reset to default. Behaviour should return to what has been the standard so far.