### PR TITLE
Fix ball spawning bug

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
@@ -168,7 +168,7 @@ public class FanGenerator : MonoBehaviour
         // Annotation for the start angle
         float startAngle = 0;
         float startRad = Mathf.Deg2Rad * startAngle;
-        Debug.Log("~~~~Generating new fan with an elevation of " + currentElevation + " and a rotation of " + currentRotation);
+        // Debug.Log("~~~~Generating new fan with an elevation of " + currentElevation + " and a rotation of " + currentRotation);
         Vector3 startPosition = new(Mathf.Cos(startRad) * fanSettings.OuterRadius, Mathf.Sin(startRad) * fanSettings.OuterRadius, 0);
         CreateTextAnnotation
         (

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -231,7 +231,7 @@ public class BocciaModel : Singleton<BocciaModel>
 
     public void SetBallStateReady()
     {
-        BallState = BocciaBallState.Ready;
+        BallState = BocciaBallState.ReadyToRelease;
     }
 
     public void SetBallStateReleased()
@@ -466,7 +466,7 @@ public class BocciaModel : Singleton<BocciaModel>
     private void ResetGameState()
     {
         GameMode = BocciaGameMode.StopPlay;
-        BallState = BocciaBallState.Ready;
+        BallState = BocciaBallState.ReadyToRelease;
 
         ResetGameOptionsToDefaults();
         // Note: SendRampChangeEvent() trigged within ResetGameOptionsToDefaults();

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -63,6 +63,7 @@ public class BocciaModel : Singleton<BocciaModel>
     public event System.Action BciChanged;
     public event System.Action NewRandomJack;
     public event System.Action BallResetChanged;
+    public event System.Action BallFallingChanged;
 
     // Hardware interface
     // TODO - create this based on game mode (live or sim)
@@ -237,6 +238,11 @@ public class BocciaModel : Singleton<BocciaModel>
     public void SetBallStateReleased()
     {
         BallState = BocciaBallState.Released;
+    }
+
+    public void HandleBallFalling()
+    {
+        SendBallFallingEvent();
     }
 
     public void ResetVirtualBalls()
@@ -454,6 +460,11 @@ public class BocciaModel : Singleton<BocciaModel>
     private void SendBallResetEvent()
     {
         BallResetChanged?.Invoke();
+    }
+
+    private void SendBallFallingEvent()
+    {
+        BallFallingChanged?.Invoke();
     }
 
     // MARK: Resetting states to Defaults

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaTypes.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaTypes.cs
@@ -22,7 +22,7 @@ public enum BocciaGameMode
 
 public enum BocciaBallState
 {
-    Ready,
+    ReadyToRelease,
     Released,
 }
 

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallFallingManager.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallFallingManager.cs
@@ -6,20 +6,25 @@ public class BallFalling : MonoBehaviour
 {
     public GameObject rampBase;
 
+    private BocciaModel _model;
+
     // Start is called before the first frame update
     void Start()
     {
+        _model = BocciaModel.Instance;
+
         if (rampBase != null)
         {
             transform.position = rampBase.transform.position;
         }
-        
     }
 
-    // Update is called once per frame
-    void Update()
+    private void OnTriggerEnter(Collider other)
     {
-        
+        if (_model.BallState == BocciaBallState.ReadyToRelease && other.gameObject.tag == "BocciaBall")
+        {
+            _model.HandleBallFalling();
+        }
     }
 }
 

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallFallingManager.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallFallingManager.cs
@@ -21,7 +21,7 @@ public class BallFalling : MonoBehaviour
 
     private void OnTriggerEnter(Collider other)
     {
-        if (_model.BallState == BocciaBallState.ReadyToRelease && other.gameObject.tag == "BocciaBall")
+        if (_model.BallState == BocciaBallState.ReadyToRelease && other.gameObject.CompareTag("BocciaBall"))
         {
             _model.HandleBallFalling();
         }

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallFallingManager.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallFallingManager.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BallFalling : MonoBehaviour
+{
+    public GameObject rampBase;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        if (rampBase != null)
+        {
+            transform.position = rampBase.transform.position;
+        }
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}
+

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallFallingManager.cs.meta
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallFallingManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9188909d1b011464f8b2638169122575
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -12,12 +12,13 @@ public class BallPresenter : MonoBehaviour
     private GameObject _activeBall; // Refers the the ball currently in use for each shot
     private int _ballCount = 0;
     private Rigidbody _ballRigidbody;
-    private float _ballFallingThreshold = -2.0f;
+    private float _ballHeightThreshold = 1.0f;
 
-    // References for the bar and elevation mechanism
+    // References for the ramp components
     public GameObject dropBar;
     public GameObject elevationPlate;
     private Animator _barAnimation;
+    public GameObject rampBase;
 
     // Variables for storing the ball transform
     private Vector3 _dropPosition;
@@ -275,12 +276,15 @@ public class BallPresenter : MonoBehaviour
         }
     }
 
+
+    // MARK: Update
     void Update()
     {
         if (_model.BallState == BocciaBallState.Ready)
         {
             // Check if the ball fell off the ramp
-            if (_activeBall.transform.position.y <= _ballFallingThreshold)
+            // by calculating the distance between the ball and the ramp's base
+            if ((_activeBall.transform.position.y - rampBase.transform.position.y) <= _ballHeightThreshold)
             {
                 // Reset the ball back onto the ramp
                 _activeBall.transform.position = elevationPlate.transform.TransformPoint(_defaultBallPosition);

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -12,7 +12,7 @@ public class BallPresenter : MonoBehaviour
     private GameObject _activeBall; // Refers the the ball currently in use for each shot
     private int _ballCount = 0;
     private Rigidbody _ballRigidbody;
-    private float _ballHeightThreshold = 1.0f;
+    //private float _ballHeightThreshold = 1.0f;
 
     // References for the ramp components
     public GameObject dropBar;
@@ -45,6 +45,7 @@ public class BallPresenter : MonoBehaviour
         _model.WasChanged += ModelChanged;
         _model.NavigationChanged += NavigationChanged;
         _model.BallResetChanged += ResetBocciaBalls;
+        _model.BallFallingChanged += HandleBallFalling;
 
         // Initialize ball
         _activeBall = GameObject.FindWithTag("BocciaBall"); // The ball already in the scene
@@ -219,7 +220,7 @@ public class BallPresenter : MonoBehaviour
     }
 
     
-    // MARK: Virtual Play Ball Reset
+    // MARK: Ball Reset
     private void ResetBocciaBalls()
     {
         // Check if at least one ball has been dropped
@@ -276,22 +277,13 @@ public class BallPresenter : MonoBehaviour
         }
     }
 
-
-    // MARK: Update
-    void Update()
+    public void HandleBallFalling()
     {
-        if (_model.BallState == BocciaBallState.ReadyToRelease)
-        {
-            // Check if the ball fell off the ramp
-            // by calculating the distance between the ball and the ramp's base
-            if ((_activeBall.transform.position.y - rampBase.transform.position.y) <= _ballHeightThreshold)
-            {
-                // Reset the ball back onto the ramp
-                _activeBall.transform.position = elevationPlate.transform.TransformPoint(_defaultBallPosition);
-                _activeBall.transform.rotation = elevationPlate.transform.rotation * _defaultBallRotation;
-            }
-        }
+        // Reset the ball back onto the ramp
+        _activeBall.transform.position = elevationPlate.transform.TransformPoint(_defaultBallPosition);
+        _activeBall.transform.rotation = elevationPlate.transform.rotation * _defaultBallRotation;
     }
+
 
     /*
     private void OnTriggerExit(Collider other)

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -106,8 +106,8 @@ public class BallPresenter : MonoBehaviour
             // Start the bar movement animation
             StartCoroutine(BarAnimation());
 
-            // Only execute the ball drop code if the Model's ball state is Ready
-            if (_model.BallState == BocciaBallState.Ready)
+            // Only execute the ball drop code if the Model's ball state is ReadyToRelease
+            if (_model.BallState == BocciaBallState.ReadyToRelease)
             {
                 // Call the method to log the drop position and rotation
                 // and the rest of the ball drop code
@@ -280,7 +280,7 @@ public class BallPresenter : MonoBehaviour
     // MARK: Update
     void Update()
     {
-        if (_model.BallState == BocciaBallState.Ready)
+        if (_model.BallState == BocciaBallState.ReadyToRelease)
         {
             // Check if the ball fell off the ramp
             // by calculating the distance between the ball and the ramp's base

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -12,6 +12,7 @@ public class BallPresenter : MonoBehaviour
     private GameObject _activeBall; // Refers the the ball currently in use for each shot
     private int _ballCount = 0;
     private Rigidbody _ballRigidbody;
+    private float _ballFallingThreshold = -2.0f;
 
     // References for the bar and elevation mechanism
     public GameObject dropBar;
@@ -21,6 +22,8 @@ public class BallPresenter : MonoBehaviour
     // Variables for storing the ball transform
     private Vector3 _dropPosition;
     private Quaternion _dropRotation;
+    private Vector3 _defaultBallPosition;
+    private Quaternion _defaultBallRotation;
 
     // Coroutines
     private Coroutine _checkBallCoroutine;
@@ -41,6 +44,10 @@ public class BallPresenter : MonoBehaviour
         // Initialize ball
         _activeBall = GameObject.FindWithTag("BocciaBall"); // The ball already in the scene
         InitializeBall();
+
+        // Calculate default ball position and rotation
+        _defaultBallPosition = elevationPlate.transform.InverseTransformPoint(_activeBall.transform.position);
+        _defaultBallRotation = Quaternion.Inverse(elevationPlate.transform.rotation) * _activeBall.transform.rotation;
 
         // Initialize bar animation
         _barAnimation = dropBar.GetComponent<Animator>();
@@ -239,6 +246,22 @@ public class BallPresenter : MonoBehaviour
             if (child.gameObject.CompareTag("BocciaBall") && child.gameObject != _activeBall)
             {
                 Destroy(child.gameObject);
+            }
+        }
+    }
+
+    void Update()
+    {
+        if (_model.BallState == BocciaBallState.Ready)
+        {
+            // Check if the ball fell off the ramp
+            if (_activeBall.transform.position.y <= _ballFallingThreshold)
+            {
+                //Debug.Log("Ball fell off the ramp");
+                // Reset the ball back onto the ramp
+                _activeBall.transform.position = elevationPlate.transform.TransformPoint(_defaultBallPosition);
+                _activeBall.transform.rotation = elevationPlate.transform.rotation * _defaultBallRotation;
+                //Debug.Log("Ball placed back on the ramp");
             }
         }
     }

--- a/Boccia-Unity/Assets/Boccia/Ramp/Ramp Prefabs/Boccia.prefab
+++ b/Boccia-Unity/Assets/Boccia/Ramp/Ramp Prefabs/Boccia.prefab
@@ -669,7 +669,7 @@ BoxCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3

--- a/Boccia-Unity/Assets/Boccia/Ramp/Ramp Prefabs/Boccia.prefab
+++ b/Boccia-Unity/Assets/Boccia/Ramp/Ramp Prefabs/Boccia.prefab
@@ -517,6 +517,7 @@ Transform:
   - {fileID: 8856341190636702082}
   - {fileID: 944599550862895331}
   - {fileID: 8617674661766376283}
+  - {fileID: 3380157153219892357}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2548263327086350593
@@ -568,6 +569,125 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   jackBall: {fileID: 2194365707095796018, guid: 59fd615ebc651804880d2713b41a5551, type: 3}
   spawnArea: {fileID: 798882925383220615}
+--- !u!1 &3746300900738591871
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3380157153219892357}
+  - component: {fileID: 9065292065552147656}
+  - component: {fileID: 7150755587687872588}
+  - component: {fileID: 1809918312498215314}
+  - component: {fileID: 7772741472945227350}
+  m_Layer: 0
+  m_Name: BallFallingThreshold
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3380157153219892357
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3746300900738591871}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 15, y: 0.5, z: 15}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 588444543545713023}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &9065292065552147656
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3746300900738591871}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &7150755587687872588
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3746300900738591871}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &1809918312498215314
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3746300900738591871}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &7772741472945227350
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3746300900738591871}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9188909d1b011464f8b2638169122575, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rampBase: {fileID: 1217801544389857873}
 --- !u!1 &4002104758346189273
 GameObject:
   m_ObjectHideFlags: 0

--- a/Boccia-Unity/Assets/Boccia/Ramp/Ramp Prefabs/Boccia.prefab
+++ b/Boccia-Unity/Assets/Boccia/Ramp/Ramp Prefabs/Boccia.prefab
@@ -534,10 +534,10 @@ MonoBehaviour:
   rotationShaft: {fileID: 8310897335574750232}
   elevationMechanism: {fileID: 1447192591350278973}
   rampAdapter: {fileID: 5816064425209161337}
-  rotationSpeed: 10
-  elevationSpeed: 5
   minElevation: 0.0026
   maxElevation: 0.43
+  _elevationSpeed: 5
+  _rotationSpeed: 5
 --- !u!114 &2165396535546456436
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -553,6 +553,7 @@ MonoBehaviour:
   ball: {fileID: 7128455000201345065, guid: 909aeb7dd77e06c47a10435a47f700a9, type: 3}
   dropBar: {fileID: 8448552161599435182}
   elevationPlate: {fileID: 9152734532760075096}
+  rampBase: {fileID: 1217801544389857873}
 --- !u!114 &7814226423708504148
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1503,6 +1504,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 81f3d8291e8cd084d97df6102502d270, type: 3}
+--- !u!1 &1217801544389857873 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4870174590861315370, guid: 81f3d8291e8cd084d97df6102502d270, type: 3}
+  m_PrefabInstance: {fileID: 6012540737330847611}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1447192591350278973 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5144694137087931462, guid: 81f3d8291e8cd084d97df6102502d270, type: 3}


### PR DESCRIPTION
[BOC-118](https://bci4kids.atlassian.net/browse/BOC-118?atlOrigin=eyJpIjoiNzhiMGJmZWRkM2M3NDM0MTkzN2UzMTRhYzMyODY3NTIiLCJwIjoiaiJ9): The ball doesn't spawn on the ramp if the ball falls due to ramp movement.

If the ramp rotates or elevates too fast, the ball can end up falling off the ramp. Either it is launched off the sides or back of the ramp, or it is thrown over the bar and rolls down when it wasn't supposed to. When it falls, the model doesn't "know" that there's no ball ready on the ramp.

To fix the bug:
- I changed the name of the ball's ready state from "Ready" to "ReadyToRelease"
- I added a BallFallingThreshold GameObject to Boccia as `IsTrigger` to detect when the ball collides. The object is positioned programmatically to align with the ramp base.
- When the ball state is "ReadyToRelease", it means the ball should be on the ramp. The `OnTriggerEnter()` method checks if the ball state is ReadyToRelease, and if the object that collided with it has the `BocciaBall` tag. Then it calls the HandleBallFalling() method in the model.
- The model sends an event that BallPresenter is subscribed to. Ball presenter moves the same ball back onto the elevation plate.
- This works for both Play and Virtual Play.


To test the changes:
- Rotate/elevate the ramp so that the ball falls off. One way to do this is to increase the rotation speed of the ramp in GameOptions menu.
- See that the ball goes back onto the ramp after falling. 
- You can also check the ball name under the Boccia GameObject in the hierarchy to see that it is the same ball (i.e. if Ball 1 fell off, Ball 1 will be reset onto the ramp - it will not generate Ball 2 yet). 
