### PR TITLE
Remove court view when navigating away

### DIFF
--- a/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
@@ -24,6 +24,7 @@ public class VirtualPlayPresenter : MonoBehaviour
 
     public Button toggleCameraButton;
     public Camera VirtualPlayCamera;
+    private bool isCourtViewOn;
 
     private BocciaModel model;
 
@@ -33,6 +34,7 @@ public class VirtualPlayPresenter : MonoBehaviour
         // cache model and subscribe for changed event
         model = BocciaModel.Instance;
         model.WasChanged += ModelChanged;
+        model.NavigationChanged += NavigationChanged;
 
         // Create a list of the virtual play buttons
         // Do not include the camera toggle button
@@ -116,6 +118,8 @@ public class VirtualPlayPresenter : MonoBehaviour
             // Allow virtual play buttons and fan to be interactable
             ToggleVirtualPlayButtons(true);
             ToggleFan(true);
+
+            isCourtViewOn = false;
         }
 
         else
@@ -126,6 +130,8 @@ public class VirtualPlayPresenter : MonoBehaviour
             // Prevent virtual play buttons and fan from being interactable
             ToggleVirtualPlayButtons(false);
             ToggleFan(false);
+
+            isCourtViewOn = true;
         }
     }
 
@@ -145,5 +151,10 @@ public class VirtualPlayPresenter : MonoBehaviour
                 segmentCollider.enabled = isInteractable;
             }
         }
+    }
+
+    private void NavigationChanged()
+    {
+        
     }
 }

--- a/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
@@ -155,6 +155,23 @@ public class VirtualPlayPresenter : MonoBehaviour
 
     private void NavigationChanged()
     {
-        
+        if (model.CurrentScreen != BocciaScreen.VirtualPlay)
+        {
+            // Disable court view camera if it is on
+            if (VirtualPlayCamera.gameObject.activeSelf)
+            {
+                VirtualPlayCamera.gameObject.SetActive(false);
+            }
+        }
+
+        if (model.CurrentScreen == BocciaScreen.VirtualPlay)
+        {
+            // Check if the court view was on before
+            if (isCourtViewOn)
+            {
+                // Re-enable court view camera
+                VirtualPlayCamera.gameObject.SetActive(true);
+            }
+        }
     }
 }


### PR DESCRIPTION
This is a fix for the bug [BOC-133](https://bci4kids.atlassian.net/browse/BOC-133?atlOrigin=eyJpIjoiYTNmZTdkNzEyODczNDE2NGFmYTQ1YzBlNTM1NDNhODAiLCJwIjoiaiJ9): Court view doesn't disappear when navigating away from virtual play screen

To fix the bug:

- I modified `VirtualPlayPresenter.cs` to turn off the court view camera when navigating away from the Virtual Play screen.
- If the court view camera was on before leaving Virtual Play, then it is turned back on when returning to Virtual Play.  

To test the changes:

- Go to Virtual Play and turn on the court view.
- Leave the court view on and click the hamburger menu button - the court view should disappear.
- Navigate back to Virtual Play, either by clicking the hamburger menu button again or by going back to the Play Menu and entering Virtual Play again. The court view camera should turn back on. 