### PR TITLE
82-ramp-resets-to-default

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
@@ -30,6 +30,7 @@ public class FanPresenter : MonoBehaviour
     
     private BocciaModel _model;
     private Quaternion _originalRotation;
+    private BocciaGameMode _lastPlayMode;
     
     // Start is called before the first frame update
     void Start()
@@ -108,15 +109,8 @@ public class FanPresenter : MonoBehaviour
     
     private void NavigationChanged()
     {
-        // Enable the fan creation only if it matched the current screen
-        if (fanTypeScreen == _model.CurrentScreen) 
-        { 
-            GenerateFanWorkflow();
-        }
-        else
-        {
-            fanGenerator.DestroyFanSegments();
-        }
+        ResetFanWhenPlayModeChanges();
+        DisplayFanOnCorrespondingScreen();
     }
 
     private void UpdateFineFan()
@@ -137,7 +131,7 @@ public class FanPresenter : MonoBehaviour
         // Otherwise, the coroutine will try to run before GameOptionsMenu is active, due to the way navigation and camera are handled, which will result in the coroutine failing for BocciaScreen.GameOptions
         if (fanTypeScreen == BocciaScreen.GameOptions)
         {
-                Debug.Log("Generating fan for GameOptionsMenu");
+                // Debug.Log("Generating fan for GameOptionsMenu");
                 fanGenerator.DestroyFanSegments();
                 CenterToOrigin();
                 CenterGameOptionsMenu();
@@ -192,6 +186,36 @@ public class FanPresenter : MonoBehaviour
             case FanPositioningMode.None:
                 fanGenerator.GenerateFanShape(_coarseFan);
                 break;
+        }
+    }
+
+    /// <summary>
+    ///  Resets the fan to generate a coarse fan if the gameMode changes
+    /// </summary>
+    private void ResetFanWhenPlayModeChanges()
+    {
+        BocciaGameMode currentPlayMode = _model.GameMode;
+        bool currentlyInPlayMode = (currentPlayMode == BocciaGameMode.Virtual) || (currentPlayMode == BocciaGameMode.Play);
+
+        if (currentlyInPlayMode && _lastPlayMode != currentPlayMode)
+        {
+            positioningMode = FanPositioningMode.CenterToBase;
+            _lastPlayMode = currentPlayMode;
+        }
+    }
+
+    /// <summary>
+    /// Displays the fan only on the the corresponding screen, as set in the inspector
+    /// </summary>
+    private void DisplayFanOnCorrespondingScreen()
+    {
+        if (fanTypeScreen == _model.CurrentScreen) 
+        { 
+            GenerateFanWorkflow();
+        }
+        else
+        {
+            fanGenerator.DestroyFanSegments();
         }
     }
 }

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -71,11 +71,13 @@ public class BocciaModel : Singleton<BocciaModel>
         switch (GameMode)
         {
             case BocciaGameMode.Play:  // Real ramp
+                // Debug.Log("Switching to hardware ramp...");
                 rampController.RampChanged -= SendRampChangeEvent;
                 rampController = _hardwareRamp;
                 rampController.RampChanged += SendRampChangeEvent;
                 break;
-            default:  // Simulated ramp
+            case BocciaGameMode.Virtual:  // Simulated ramp
+                // Debug.Log("Switching to simulated ramp...");
                 rampController.RampChanged -= SendRampChangeEvent;
                 rampController = _simulatedRamp;
                 rampController.RampChanged += SendRampChangeEvent;

--- a/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
@@ -22,11 +22,14 @@ public class RampPresenter : MonoBehaviour
 
     private Vector3 elevationDirection; // Vector to define the direction of motion of the elevationMechanism visualization
 
+    private BocciaGameMode _lastPlayMode;
+
     void Start()
     {
         // cache model and subscribe for changed event
         _model = BocciaModel.Instance;
         _model.WasChanged += ModelChanged;
+        _model.NavigationChanged += NavigationChanged;
 
         // Convert rampAdapter z-axis to local space of elevationMechanism parent to get the direction for the elevationMechanism visualization
         Vector3 rampDirection = rampAdapter.transform.forward;
@@ -34,6 +37,9 @@ public class RampPresenter : MonoBehaviour
 
         // initialize ramp to saved data
         ModelChanged();
+
+        // Initialize the last play mode as virtual play
+        _lastPlayMode = BocciaGameMode.Virtual;
     }
 
     void OnDisable()
@@ -56,6 +62,12 @@ public class RampPresenter : MonoBehaviour
         //Debug.Log(model.RampRotation);
         StartCoroutine(RotationVisualization());
         StartCoroutine(ElevationVisualization());
+    }
+
+    private void NavigationChanged()
+    {
+        // Reset the ramp if the play mode changes
+        ResetRampWhenPlayModeChanges();
     }
 
     private IEnumerator RotationVisualization()
@@ -95,6 +107,19 @@ public class RampPresenter : MonoBehaviour
 
         elevationMechanism.transform.localPosition = targetElevation;
         _model.SetRampMoving(false);
+    }
+
+    private void ResetRampWhenPlayModeChanges()
+    {
+        BocciaGameMode currentPlayMode = _model.GameMode;
+        bool currentlyInPlayMode = (currentPlayMode == BocciaGameMode.Virtual) || (currentPlayMode == BocciaGameMode.Play);
+
+        if (currentlyInPlayMode && _lastPlayMode != currentPlayMode)
+        {
+            Debug.Log("Resetting ramp position");
+            _model.ResetRampPosition();
+            _lastPlayMode = currentPlayMode;
+        }
     }
 
 }


### PR DESCRIPTION
Resets ramp poisition to default if play mode changes (i.e., navigating from VirtualPlay to Play or viceversa). 

Implementations
- Navigation-based method in ramp presenter to reset the ramp position if the play mode changes
- Navigation-based method in fan presenter to reset the fan position if the play mode changes. This ensures that the coarse fan is always displayed first if the play mode changes. The last fan will be displayed if the play mode does not change (e.g., fine fan will be displayed again when returting to the last play mode.
- Additionally created method to `DisplayFanOnCorrespondingScreen` to keep the `NavigationChanged` method in FanPresenter cleaner.

Testing instructions
- Start the software and navigate to Play or VirtualPlay.
- Mode the ramp using the fan controller.
- Navigate and return to the same play mode, fan and position should be the same as before
- Navigate to the opposite play mode, the ramp should reset and the fan should be coarse fan.