### PR TITLE
90-play-random-ball

### DIFF
--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -221,6 +221,7 @@ public class BocciaModel : Singleton<BocciaModel>
     public void SendSerialCommandList() => _hardwareRamp.SendSerialCommandList();
     public void ResetSerialCommands() => _hardwareRamp.ResetSerialCommands();
     public Task<string> ReadSerialCommandAsync() => _hardwareRamp.ReadSerialCommandAsync();
+    public void RandomBallDrop(int randomRotation, int randomElevation) => _hardwareRamp.RandomBallDrop(randomRotation, randomElevation);
 
     // Method to reset the state of the bar after the ball has been dropped
     public void ResetBar()

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -82,6 +82,14 @@ public class HardwareRamp : RampController, ISerialController
         SendChangeEvent();
     }
 
+    public void RandomBallDrop(int randomRotation, int randomElevation)
+    {
+        RotateTo(randomRotation);
+        ElevateTo(randomElevation);
+        DropBall();
+        SendChangeEvent();
+    }
+
     public void DropBall()
     {
         IsBarOpen = true; // Toggle bar state

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -87,7 +87,6 @@ public class HardwareRamp : RampController, ISerialController
         RotateTo(randomRotation);
         ElevateTo(randomElevation);
         DropBall();
-        SendChangeEvent();
     }
 
     public void DropBall()

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -111,6 +111,12 @@ public class BallPresenter : MonoBehaviour
     // MARK: Bar Animation
     private IEnumerator BarAnimation()
     {
+        // Wait for the ramp to stop moving
+        while (_model.IsRampMoving)
+        {
+            yield return null;
+        }
+
         _model.SetRampMoving(true);
 
         // Bar opening and closing animation

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -171,8 +171,11 @@ public class BallPresenter : MonoBehaviour
 
     private IEnumerator CheckBallSpeed()
     {
-        // Wait a bit for the ball to fully get rolling
-        yield return new WaitForSecondsRealtime(3f);
+        // Wait for the bar animation to finish
+        while (_barAnimation.GetCurrentAnimatorStateInfo(0).IsName("DropBarClosed"))
+        {
+            yield return null;
+        }
 
         // Velocity threshold
         while (_ballRigidbody.velocity.magnitude > 0.01f)

--- a/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
@@ -54,13 +54,26 @@ public class RampPresenter : MonoBehaviour
 
         // Ramp is a digital twin, so we just match visualization with model data
         //Debug.Log(model.RampRotation);
-        StartCoroutine(RotationVisualization());
-        StartCoroutine(ElevationVisualization());
+        StartCoroutine(RampVisualization());
+    }
+
+    private IEnumerator RampVisualization()
+    {
+        // Wait for ramp to stop moving before visualizing
+        while (_model.IsRampMoving)
+        {
+            yield return null;
+        }
+
+        // Visualize the ramp moving, first rotate, then elevate
+        _model.SetRampMoving(true);
+        yield return StartCoroutine(RotationVisualization());
+        yield return StartCoroutine(ElevationVisualization());
+        _model.SetRampMoving(false);
     }
 
     private IEnumerator RotationVisualization()
     {
-        _model.SetRampMoving(true);
         // Smoothly show the rotatation of the ramp to the new position
         Quaternion currentRotation = rotationShaft.transform.localRotation;
         //Debug.Log("Current Rotation: " + currentRotation.eulerAngles);
@@ -75,12 +88,10 @@ public class RampPresenter : MonoBehaviour
         }
 
         rotationShaft.transform.localRotation = targetQuaternion;
-        _model.SetRampMoving(false);
     }
 
     private IEnumerator ElevationVisualization()
     {
-        _model.SetRampMoving(true);
         Vector3 currentElevation = elevationMechanism.transform.localPosition;
         //Debug.Log($"model.RampElevation value: {model.RampElevation}");
         float elevationScalar = minElevation + (_model.RampElevation / 100f) * (maxElevation - minElevation); // Convert percent elevation to its scalar value
@@ -98,7 +109,6 @@ public class RampPresenter : MonoBehaviour
         }
 
         elevationMechanism.transform.localPosition = targetElevation;
-        _model.SetRampMoving(false);
     }
 
 }

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -59,5 +59,18 @@ public class PlayScreenPresenter : MonoBehaviour
         _randomElevation = Random.Range(0, 100+1);
 
         _model.RandomBallDrop(_randomRotation, _randomElevation);
+
+        StartCoroutine(WaitForStopBeforeRampReset());
+    }
+
+    private IEnumerator WaitForStopBeforeRampReset()
+    {  
+        while (_model.IsRampMoving)
+        {
+            yield return null;
+        }
+
+        _model.ResetRampPosition();
+
     }
 }

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -55,8 +55,8 @@ public class PlayScreenPresenter : MonoBehaviour
         // Generate random values for the ball drop position
         // add +1 to max to maxe it inclusive
         // TODO: The min and max values should come from the model, not hard coded
-        _randomRotation = Random.Range(5, 181);
-        _randomElevation = Random.Range(1, 101);
+        _randomRotation = Random.Range(-85, 85+1);
+        _randomElevation = Random.Range(0, 100+1);
 
         _model.RandomBallDrop(_randomRotation, _randomElevation);
     }

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -6,17 +6,22 @@ using UnityEngine.UI;
 public class PlayScreenPresenter : MonoBehaviour
 {
     public Button resetRampButton;
-    //public Button randomBallButton;
+    public Button randomBallButton;
 
     private BocciaModel _model;
+
+    private int _randomRotation;
+    private int _randomElevation;
 
     // Start is called before the first frame update
     void Start()
     {
-        // _model = BocciaModel.Instance;
+        _model = BocciaModel.Instance;
 
         // connect buttons to model
         resetRampButton.onClick.AddListener(_model.ResetRampPosition);
+        randomBallButton.onClick.AddListener(SetRandomBallDropPosition);
+        
         // TODO: see task BOC-90 for what the random ball button should do
     }
 
@@ -43,5 +48,16 @@ public class PlayScreenPresenter : MonoBehaviour
     private void ModelChanged()
     {
 
+    }
+
+    private void SetRandomBallDropPosition()
+    {
+        // Generate random values for the ball drop position
+        // add +1 to max to maxe it inclusive
+        // TODO: The min and max values should come from the model, not hard coded
+        _randomRotation = Random.Range(5, 181);
+        _randomElevation = Random.Range(1, 101);
+
+        _model.RandomBallDrop(_randomRotation, _randomElevation);
     }
 }

--- a/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
+++ b/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
@@ -1610,6 +1610,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1be0eb6300d20d144979fdd1fb66a6e7, type: 3}
+--- !u!114 &1281730594 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3214086637462062914, guid: 61bd1dc80c9f06c45b87ea455ac607ff, type: 3}
+  m_PrefabInstance: {fileID: 5907942768798430780}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1328160566 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1649985292535673242, guid: 42ce536088f800e4d94b8a8c92ae7277, type: 3}
@@ -3814,6 +3825,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 2146497314}
     m_Modifications:
+    - target: {fileID: 259447462842585429, guid: 61bd1dc80c9f06c45b87ea455ac607ff, type: 3}
+      propertyPath: randomBallButton
+      value: 
+      objectReference: {fileID: 1281730594}
     - target: {fileID: 3425727482096386981, guid: 61bd1dc80c9f06c45b87ea455ac607ff, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0


### PR DESCRIPTION
- Random ball in play mode moves the `HardwareRamp` to a random rotation and elevantion and then drops the ball.
- Additionally I modified the `RampPresenter` and `BallPresenter` to wait until the ramp has stopped moving so the movements (i.e., rotation first, then elevation, then drop) are subsequent rather than concurrent.

Note
- This is missing the model rotation and elevation max and min values, so they are currently hardcoded in `PlayScreenPresenter.SetRandomBallPosition`