### PR TITLE
Fix pink fan in game options

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
@@ -10,6 +10,10 @@ using UnityEngine.Rendering;
 
 public class FanGenerator : MonoBehaviour
 {
+    [Tooltip("Should be Sprites-Default")]
+    public Material material;
+    public Color colour = Color.grey;
+
     public void GenerateFanShape(FanSettings fanSettings)
     {        
         float angleStep = fanSettings.Theta / fanSettings.NColumns;
@@ -37,16 +41,9 @@ public class FanGenerator : MonoBehaviour
 
     public void CreateFanSegment(float startAngle, float endAngle, float innerRadius, float outerRadius)
     {
-        GameObject segment = new("FanSegment");
-        segment.transform.SetParent(transform);
-        segment.transform.localPosition = Vector3.zero;
-        segment.transform.localScale = Vector3.one;
-
-        MeshFilter meshFilter = segment.AddComponent<MeshFilter>();
-        MeshRenderer meshRenderer = segment.AddComponent<MeshRenderer>();
-
         int segments = 100; // Number of segments to approximate the arc
-        meshFilter.mesh = GenerateFanMesh(startAngle, endAngle, innerRadius, outerRadius, segments);
+        Mesh fanMesh = GenerateFanMesh(startAngle, endAngle, innerRadius, outerRadius, segments);
+        GameObject segment = CreateMeshObject("FanSegment", fanMesh);
 
         segment.transform.SetLocalPositionAndRotation
         (
@@ -60,18 +57,11 @@ public class FanGenerator : MonoBehaviour
         // If no backbutton, skip method
         if (positionMode == BackButtonPositioningMode.None) return;
 
-        GameObject backButton = new("BackButton");
-        backButton.transform.SetParent(transform);
-        backButton.transform.localPosition = Vector3.zero;
-        backButton.transform.localScale = Vector3.one;
-
-        MeshFilter meshFilter = backButton.AddComponent<MeshFilter>();
-        MeshRenderer meshRenderer = backButton.AddComponent<MeshRenderer>();
-        
         float startAngle = 0;
         float endAngle = fanSettings.BackButtonWidth / fanSettings.OuterRadius * Mathf.Rad2Deg; // Calculate the end angle for the back button
         int segments = 10; // Number of segments to approximate the arc
-        meshFilter.mesh = GenerateFanMesh(startAngle, endAngle, fanSettings.InnerRadius, fanSettings.OuterRadius, segments);
+        Mesh fanMesh = GenerateFanMesh(startAngle, endAngle, fanSettings.InnerRadius, fanSettings.OuterRadius, segments);
+        GameObject backButton = CreateMeshObject("BackButton", fanMesh);
 
         // Position the back button based on the BackButtonPositioningMode
         float rotationOffset = 0;
@@ -94,16 +84,9 @@ public class FanGenerator : MonoBehaviour
 
     public void GenerateDropButton(FanSettings fanSettings)
     {
-        GameObject dropButton = new("DropButton");
-        dropButton.transform.SetParent(transform);
-        dropButton.transform.localPosition = Vector3.zero;
-        dropButton.transform.localScale = Vector3.one;
-
-        MeshFilter meshFilter = dropButton.AddComponent<MeshFilter>();
-        MeshRenderer meshRenderer = dropButton.AddComponent<MeshRenderer>();
-        
-        int segments = 50; // Number of segments to approximate the arc
-        meshFilter.mesh = GenerateFanMesh(0, fanSettings.Theta, fanSettings.InnerRadius-fanSettings.DropButtonHeight, fanSettings.InnerRadius-fanSettings.rowSpacing, segments);
+        int segments = 10; // Number of segments to approximate the arc
+        Mesh fanMesh = GenerateFanMesh(0, fanSettings.Theta, fanSettings.InnerRadius - fanSettings.DropButtonHeight, fanSettings.InnerRadius - fanSettings.rowSpacing, segments);
+        GameObject dropButton = CreateMeshObject("DropButton", fanMesh);
 
         dropButton.transform.SetLocalPositionAndRotation
         (
@@ -120,14 +103,29 @@ public class FanGenerator : MonoBehaviour
         }
     }
 
+    private GameObject CreateMeshObject(string objectName, Mesh generatedMesh)
+    {
+        GameObject meshObject = new(objectName);
+        meshObject.transform.SetParent(transform);
+        meshObject.transform.localPosition = Vector3.zero;
+        meshObject.transform.localScale = Vector3.one;
+
+        MeshFilter meshFilter = meshObject.AddComponent<MeshFilter>();
+        meshFilter.mesh = generatedMesh;
+
+        MeshRenderer meshRenderer = meshObject.AddComponent<MeshRenderer>();
+        meshRenderer.material = material;
+        meshRenderer.material.color = colour;
+
+        return meshObject;
+    }
+
     private Mesh GenerateFanMesh(float startAngle, float endAngle, float innerRadius, float outerRadius, int segments)
     {
         Mesh mesh = new();
-        
         int verticesCount = (segments + 1) * 2;
         Vector3[] vertices = new Vector3[verticesCount];
         int[] triangles = new int[segments * 6];
-
         float angleStep = (endAngle - startAngle) / segments;
 
         for (int i = 0; i <= segments; i++)

--- a/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
@@ -137,7 +137,7 @@ public class FanPresenter : MonoBehaviour
         // Otherwise, the coroutine will try to run before GameOptionsMenu is active, due to the way navigation and camera are handled, which will result in the coroutine failing for BocciaScreen.GameOptions
         if (fanTypeScreen == BocciaScreen.GameOptions)
         {
-                Debug.Log("Generating fan for GameOptionsMenu");
+                // Debug.Log("Generating fan for GameOptionsMenu");
                 fanGenerator.DestroyFanSegments();
                 CenterToOrigin();
                 CenterGameOptionsMenu();

--- a/Boccia-Unity/Assets/Boccia/BCI/RampControlFan.prefab
+++ b/Boccia-Unity/Assets/Boccia/BCI/RampControlFan.prefab
@@ -65,6 +65,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4c0fd8cb5a1624f41b58da45ca099ee4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  material: {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  colour: {r: 0.5, g: 0.5, b: 0.5, a: 1}
 --- !u!114 &-7705321522961072228
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
[BOC-136](https://bci4kids.atlassian.net/browse/BOC-136): Game options fan is missing texture so it renders pink

Changes:
- Added material and colour inspector parameters to `FanGenerator`
- Moved duplicate code into helper method: `CreateMeshObject`
- Applied material and colour selections to created mesh renderers
- Assigned material reference in `RampControlFan` prefab - ***Modified Prefab***

To Test:
- Open game options view to confirm fan is still visible and no longer pink
- Start virtual play to confirm that gameplay fan is visible
- Trigger stimulus in virtual play to confirm presentation is not comprimised