### PR TITLE
Don't display a new fan until the ramp stops

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
@@ -151,6 +151,12 @@ public class FanPresenter : MonoBehaviour
         // Force a frame to force fan segments destruction complete before generating the fan shape
         yield return null;
 
+        // If the ramp is moving, wait for it to stop before generating the fan
+        while (_model.IsRampMoving)
+        {
+            yield return null;
+        }
+
         // Reset to original rotation to avoid cumulative effects
         CenterToOrigin();
 


### PR DESCRIPTION
[BOC-128:](https://bci4kids.atlassian.net/browse/BOC-128?atlOrigin=eyJpIjoiYjY4N2I5MGQxOGNjNGVhOWIwMjhkNGVmMjZjN2YwY2QiLCJwIjoiaiJ9) New fan should not display until ramp stops

Changes:
- The `GenerateFanCoroutine()` in `FanPresenter.cs` removes the previous fan, and then waits for `IsRampMoving` to be False before generating the new fan. So, no fan is displayed while the ramp is in motion. 

Testing:
- Navigate to Play or Virtual Play, and select a fan segment. You should see that first fan disappear, and the new fan should only appear after the ramp stops.

Note: Because of the [BOC-135](https://bci4kids.atlassian.net/jira/software/c/projects/BOC/boards/11/backlog?selectedIssue=BOC-135) bug, this new fan behavior won't work when the Reset Ramp button is pressed. Other than that, the fan will disappear/appear properly when moving the ramp using the fan.