### PR TITLE
BOC126 and 127: Rotation and Elevation parameters are int

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
@@ -119,8 +119,8 @@ public class FanPresenter : MonoBehaviour
         if (_fineFan != null)
         {
             _fineFan.Theta = _model.GameOptions.RotationRange;
-            _fineFan.NColumns = (int)_model.GameOptions.RotationPrecision;
-            _fineFan.NRows = (int)_model.GameOptions.ElevationPrecision;
+            _fineFan.NColumns = _model.GameOptions.RotationPrecision;
+            _fineFan.NRows = _model.GameOptions.ElevationPrecision;
             _fineFan.ElevationRange = _model.GameOptions.ElevationRange;
         }
     }

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaData.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaData.cs
@@ -72,12 +72,12 @@ public class HardwareSettingsContainer
 public class GameOptionsContainer
 {
     public Color BallColor;
-    public float ElevationPrecision;
-    public float ElevationRange;
-    public float ElevationSpeed;
-    public float RotationPrecision;
-    public float RotationRange;
-    public float RotationSpeed;
+    public int ElevationPrecision;
+    public int ElevationRange;
+    public int ElevationSpeed;
+    public int RotationPrecision;
+    public int RotationRange;
+    public int RotationSpeed;
 
     // Empty dictionary to hold possible ball colors
     // Define this list within BocciaModel

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -157,14 +157,14 @@ public class BocciaModel : Singleton<BocciaModel>
         }
 
         // User values
-        bocciaData.GameOptions.ElevationPrecision = 3.0f;
-        bocciaData.GameOptions.ElevationRange = 20.0f;
-        bocciaData.GameOptions.RotationPrecision = 3.0f;
-        bocciaData.GameOptions.RotationRange = 20.0f;
+        bocciaData.GameOptions.ElevationPrecision = 3;
+        bocciaData.GameOptions.ElevationRange = 20;
+        bocciaData.GameOptions.RotationPrecision = 3;
+        bocciaData.GameOptions.RotationRange = 20;
 
         // Operator values
-        bocciaData.GameOptions.ElevationSpeed = 5.0f;
-        bocciaData.GameOptions.RotationSpeed = 5.0f;
+        bocciaData.GameOptions.ElevationSpeed = 5;
+        bocciaData.GameOptions.RotationSpeed = 5;
 
         // Note: SendRampChangeEvent() trigged within ResetGameOptionsToDefaults();
     }

--- a/Boccia-Unity/Assets/Boccia/UI/GameOptionsMenuPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/GameOptionsMenuPresenter.cs
@@ -110,36 +110,36 @@ public class GameOptionsMenuPresenter : MonoBehaviour
 
     public void OnChangeElevationPrecision(float value)
     {
-        _model.SetGameOption(ref _model.GameOptions.ElevationPrecision, value);
+        _model.SetGameOption(ref _model.GameOptions.ElevationPrecision, Mathf.RoundToInt(value));
         GenerateFanForOptions();
     }
 
     public void OnChangeElevationRange(float value)
     {
-        _model.SetGameOption(ref _model.GameOptions.ElevationRange, value);
+        _model.SetGameOption(ref _model.GameOptions.ElevationRange, Mathf.RoundToInt(value));
         GenerateFanForOptions();
     }
 
     public void OnChangeRotationPrecision(float value)
     {
-        _model.SetGameOption(ref _model.GameOptions.RotationPrecision, value);
+        _model.SetGameOption(ref _model.GameOptions.RotationPrecision, Mathf.RoundToInt(value));
         GenerateFanForOptions();
     }
 
     public void OnChangeRotationRange(float value)
     {
-        _model.SetGameOption(ref _model.GameOptions.RotationRange, value);
+        _model.SetGameOption(ref _model.GameOptions.RotationRange, Mathf.RoundToInt(value));
         GenerateFanForOptions();
     }
 
     public void OnChangeElevationSpeed(float value)
     {
-        _model.SetGameOption(ref _model.GameOptions.ElevationSpeed, value);
+        _model.SetGameOption(ref _model.GameOptions.ElevationSpeed, Mathf.RoundToInt(value));
     }
 
     public void OnChangeRotationSpeed(float value)
     {
-        _model.SetGameOption(ref _model.GameOptions.RotationSpeed, value);
+        _model.SetGameOption(ref _model.GameOptions.RotationSpeed, Mathf.RoundToInt(value));
     }
 
     // Reset game options to defaults

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/GameOptionsMenu.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/GameOptionsMenu.prefab
@@ -6045,7 +6045,7 @@ MonoBehaviour:
   m_Direction: 0
   m_MinValue: 0
   m_MaxValue: 1
-  m_WholeNumbers: 0
+  m_WholeNumbers: 1
   m_Value: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -6354,8 +6354,8 @@ MonoBehaviour:
   m_Direction: 0
   m_MinValue: 0
   m_MaxValue: 1
-  m_WholeNumbers: 0
-  m_Value: 0.346
+  m_WholeNumbers: 1
+  m_Value: 0
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -16055,8 +16055,8 @@ MonoBehaviour:
   m_Direction: 0
   m_MinValue: 0
   m_MaxValue: 1
-  m_WholeNumbers: 0
-  m_Value: 0.25
+  m_WholeNumbers: 1
+  m_Value: 0
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []


### PR DESCRIPTION
As per [BOC126](https://bci4kids.atlassian.net/browse/BOC-126) and [BOC127](https://bci4kids.atlassian.net/browse/BOC-127).

Rotation and Elevation parameters (precision, range, speed) were unnecessarily set to float. They have been changed to int. [](url)

Test:
- Go to Game Options Menu, change the values. The fine fan updates on the game options menu and in Play mode.
- *NOTE*: Fine fan rendering on the Game Options Menu is wonky as per bug reported in [BOC144](https://bci4kids.atlassian.net/browse/BOC-144)