### PR TITLE
144 fix options fan culling

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
@@ -10,7 +10,6 @@ using UnityEngine.Rendering;
 
 public class FanGenerator : MonoBehaviour
 {
-    [Tooltip("Should be Sprites-Default")]
     public Material material;
     public Color colour = Color.grey;
 
@@ -43,13 +42,7 @@ public class FanGenerator : MonoBehaviour
     {
         int segments = 100; // Number of segments to approximate the arc
         Mesh fanMesh = GenerateFanMesh(startAngle, endAngle, innerRadius, outerRadius, segments);
-        GameObject segment = CreateMeshObject("FanSegment", fanMesh);
-
-        segment.transform.SetLocalPositionAndRotation
-        (
-            new Vector3(segment.transform.localPosition.x, segment.transform.localPosition.y, 0),
-            Quaternion.Euler(0, 0, 0)
-        );
+        CreateMeshObject("FanSegment", fanMesh);
     }
 
    public void GenerateBackButton(FanSettings fanSettings, BackButtonPositioningMode positionMode)
@@ -61,7 +54,6 @@ public class FanGenerator : MonoBehaviour
         float endAngle = fanSettings.BackButtonWidth / fanSettings.OuterRadius * Mathf.Rad2Deg; // Calculate the end angle for the back button
         int segments = 10; // Number of segments to approximate the arc
         Mesh fanMesh = GenerateFanMesh(startAngle, endAngle, fanSettings.InnerRadius, fanSettings.OuterRadius, segments);
-        GameObject backButton = CreateMeshObject("BackButton", fanMesh);
 
         // Position the back button based on the BackButtonPositioningMode
         float rotationOffset = 0;
@@ -74,25 +66,15 @@ public class FanGenerator : MonoBehaviour
                 rotationOffset = -(fanSettings.columnSpacing + endAngle);
                 break;
         }
-        
-        backButton.transform.SetLocalPositionAndRotation
-        (
-            new Vector3(backButton.transform.localPosition.x, backButton.transform.localPosition.y, 0),
-            Quaternion.Euler(0, 0, rotationOffset)
-        );
+
+        CreateMeshObject("BackButton", fanMesh, rotationOffset);
     }
 
     public void GenerateDropButton(FanSettings fanSettings)
     {
         int segments = 10; // Number of segments to approximate the arc
         Mesh fanMesh = GenerateFanMesh(0, fanSettings.Theta, fanSettings.InnerRadius - fanSettings.DropButtonHeight, fanSettings.InnerRadius - fanSettings.rowSpacing, segments);
-        GameObject dropButton = CreateMeshObject("DropButton", fanMesh);
-
-        dropButton.transform.SetLocalPositionAndRotation
-        (
-            new Vector3(dropButton.transform.localPosition.x, dropButton.transform.localPosition.y, 0),
-            Quaternion.Euler(0, 0, 0)
-        );
+        CreateMeshObject("DropButton", fanMesh);
     }
 
     public void DestroyFanSegments()
@@ -103,11 +85,12 @@ public class FanGenerator : MonoBehaviour
         }
     }
 
-    private GameObject CreateMeshObject(string objectName, Mesh generatedMesh)
+    private GameObject CreateMeshObject(string objectName, Mesh generatedMesh, float eulerRotation = 0)
     {
         GameObject meshObject = new(objectName);
         meshObject.transform.SetParent(transform);
         meshObject.transform.localPosition = Vector3.zero;
+        meshObject.transform.localEulerAngles = new Vector3(0, 0, eulerRotation);
         meshObject.transform.localScale = Vector3.one;
 
         MeshFilter meshFilter = meshObject.AddComponent<MeshFilter>();

--- a/Boccia-Unity/Assets/Boccia/BCI/RampControlFan.prefab
+++ b/Boccia-Unity/Assets/Boccia/BCI/RampControlFan.prefab
@@ -65,7 +65,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4c0fd8cb5a1624f41b58da45ca099ee4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  material: {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  material: {fileID: 2100000, guid: fc80352a2baed914fa228646173e5f3f, type: 2}
   colour: {r: 0.5, g: 0.5, b: 0.5, a: 1}
 --- !u!114 &-7705321522961072228
 MonoBehaviour:

--- a/Boccia-Unity/Assets/Materials/UI Control Fan.mat
+++ b/Boccia-Unity/Assets/Materials/UI Control Fan.mat
@@ -1,0 +1,91 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI Control Fan
+  m_Shader: {fileID: 10755, guid: 0000000000000000f000000000000000, type: 0}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _ColorMask: 15
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UVSec: 0
+    - _UseUIAlphaClip: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _Specular: {r: 0, g: 0, b: 0, a: 0}
+  m_BuildTextureStacks: []

--- a/Boccia-Unity/Assets/Materials/UI Control Fan.mat.meta
+++ b/Boccia-Unity/Assets/Materials/UI Control Fan.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fc80352a2baed914fa228646173e5f3f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
[BOC-144](https://bci4kids.atlassian.net/browse/BOC-144): FineFan rendering within GameOptionsMenu is wonky

Changes:
- Created new basic unlit material: `UI Control Fan`
- Assigned new material to `RampControlFan` prefab - ***Modified Prefab***
- Removed now misleading tooltip in `FanGenerator`
- Further aggregated duplicate code in `FanGenerator` into helper method

To Test:
- Open Game options view, slide rotation range to max
- Start virtual play, confirm gameplay fan is unaffected
- Trigger stimulus to confirm presentation is not comprimised