### PR TITLE
Serial connection status indicator

### DIFF
--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -2,11 +2,13 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using TMPro;
 
 public class PlayScreenPresenter : MonoBehaviour
 {
     public Button resetRampButton;
     public Button randomBallButton;
+    public GameObject serialStatusIndicator;
 
     private BocciaModel _model;
 
@@ -21,8 +23,6 @@ public class PlayScreenPresenter : MonoBehaviour
         // connect buttons to model
         resetRampButton.onClick.AddListener(_model.ResetRampPosition);
         randomBallButton.onClick.AddListener(SetRandomBallDropPosition);
-        
-        // TODO: see task BOC-90 for what the random ball button should do
     }
 
     // Update is called once per frame
@@ -38,6 +38,8 @@ public class PlayScreenPresenter : MonoBehaviour
             _model = BocciaModel.Instance;
         }
         _model.WasChanged += ModelChanged;
+
+        SerialConnectionStatus();
     }
 
     void OnDisable()
@@ -71,6 +73,20 @@ public class PlayScreenPresenter : MonoBehaviour
         }
 
         _model.ResetRampPosition();
+    }
 
+    private void SerialConnectionStatus()
+    {
+        if (_model.HardwareSettings.IsSerialPortConnected)
+        {
+            serialStatusIndicator.GetComponentInChildren<TextMeshProUGUI>().text = "Serial Connected";
+            serialStatusIndicator.GetComponent<Image>().color = Color.green;
+        }
+
+        if (!_model.HardwareSettings.IsSerialPortConnected)
+        {
+            serialStatusIndicator.GetComponentInChildren<TextMeshProUGUI>().text = "Serial Disconnected";
+            serialStatusIndicator.GetComponent<Image>().color = Color.red;
+        }
     }
 }

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -46,7 +46,10 @@ public class PlayScreenPresenter : MonoBehaviour
         _model.WasChanged += ModelChanged;
         _model.NavigationChanged += NavigationChanged;
 
-        CheckConnectionInPlayMode();
+        if (_model.GameMode == BocciaGameMode.Play)
+        {
+            _checkSerialCoroutine = StartCoroutine(CheckSerialPortConnection());
+        }
     }
 
     void OnDisable()
@@ -96,28 +99,14 @@ public class PlayScreenPresenter : MonoBehaviour
 
         _model.ResetRampPosition();
     }
-
-
-    private void CheckConnectionInPlayMode()
-    {
-        // Start checking the serial connection if we are in play mode
-        if (_model.GameMode == BocciaGameMode.Play)
-        {
-            // Initialize the indicator
-            lastConnectionStatus = IsPortConnected(_model.HardwareSettings.COMPort);
-            IndicateSerialStatus(lastConnectionStatus);
-
-            // Start the coroutine
-            _checkSerialCoroutine = StartCoroutine(CheckSerialPortConnection());
-        }
-    }
+    
 
     private IEnumerator CheckSerialPortConnection()
     {
         // Keep checking the serial connection
         while (true)
         {
-            // Debug.Log("Checking serial connection");
+            Debug.Log("Checking serial connection");
 
             // Check the serial port connection
             bool currentStatus = IsPortConnected(_model.HardwareSettings.COMPort);

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -123,6 +123,7 @@ public class PlayScreenPresenter : MonoBehaviour
 
         // Navigate to the ramp setup screen which displays in play menu
         _model.PlayMenu();
+        _model.HardwareSettings.IsSerialPortConnected = false;
         _model.ShowRampSetup();
 
         yield return null;

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -99,7 +99,7 @@ public class PlayScreenPresenter : MonoBehaviour
 
         _model.ResetRampPosition();
     }
-    
+
 
     private IEnumerator CheckSerialPortConnection()
     {
@@ -110,6 +110,7 @@ public class PlayScreenPresenter : MonoBehaviour
 
             // Check the serial port connection
             bool currentStatus = IsPortConnected(_model.HardwareSettings.COMPort);
+            IndicateSerialStatus(currentStatus);
 
             // If the status has changed since the last check
             // update the indicator

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -112,7 +112,7 @@ public class PlayScreenPresenter : MonoBehaviour
         {
             // Check every 6 seconds to reduce computational load
             yield return new WaitForSecondsRealtime(_waitTime);
-            Debug.Log("Checking serial connection");
+            // Debug.Log("Checking serial connection");
         }
 
         // If disconnected, update the indicator

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -12,6 +12,7 @@ public class PlayScreenPresenter : MonoBehaviour
     public GameObject serialStatusIndicator;
     private bool lastConnectionStatus;
     private Coroutine _checkSerialCoroutine;
+    private float _waitTime = 6f;
 
     private BocciaModel _model;
 
@@ -33,7 +34,7 @@ public class PlayScreenPresenter : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        
+
     }
 
     void OnEnable()
@@ -116,22 +117,22 @@ public class PlayScreenPresenter : MonoBehaviour
         // Keep checking the serial connection
         while (true)
         {
+            // Debug.Log("Checking serial connection");
+
             // Check the serial port connection
             bool currentStatus = IsPortConnected(_model.HardwareSettings.COMPort);
-            Debug.Log("Connection status: " + currentStatus);
 
             // If the status has changed since the last check
             // update the indicator
             if (lastConnectionStatus != currentStatus)
             {
                 lastConnectionStatus = currentStatus;
-                Debug.Log("Last connection status: " + lastConnectionStatus);
 
                 IndicateSerialStatus(lastConnectionStatus);
             }
 
             // Check every 6 seconds to reduce computational load
-            yield return new WaitForSecondsRealtime(6f);
+            yield return new WaitForSecondsRealtime(_waitTime);
         }
     }
 

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/PlayScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/PlayScreen.prefab
@@ -134,6 +134,82 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &280350794043064211
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2535906362390168204}
+  - component: {fileID: 4224587864108413799}
+  - component: {fileID: 4307748276741138668}
+  m_Layer: 6
+  m_Name: SerialConnectionStatus
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2535906362390168204
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 280350794043064211}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4501055880234706403}
+  m_Father: {fileID: 6855669459162382914}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: -120, y: 200}
+  m_SizeDelta: {x: 220, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4224587864108413799
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 280350794043064211}
+  m_CullTransparentMesh: 1
+--- !u!114 &4307748276741138668
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 280350794043064211}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &1087478738280944160
 GameObject:
   m_ObjectHideFlags: 0
@@ -255,6 +331,140 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &2136889402653620579
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4501055880234706403}
+  - component: {fileID: 1484606777777913390}
+  - component: {fileID: 3267944251757233166}
+  m_Layer: 6
+  m_Name: ConnectionStatusText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4501055880234706403
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2136889402653620579}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2535906362390168204}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 220, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1484606777777913390
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2136889402653620579}
+  m_CullTransparentMesh: 1
+--- !u!114 &3267944251757233166
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2136889402653620579}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Connection Status
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &2543338226600476465
 GameObject:
   m_ObjectHideFlags: 0
@@ -677,6 +887,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   resetRampButton: {fileID: 6748951209935578255}
+  randomBallButton: {fileID: 0}
 --- !u!1 &7973036634516842441
 GameObject:
   m_ObjectHideFlags: 0
@@ -711,6 +922,7 @@ RectTransform:
   - {fileID: 8661612199352977746}
   - {fileID: 3529464456708228205}
   - {fileID: 5152801133456465712}
+  - {fileID: 2535906362390168204}
   m_Father: {fileID: 3425727482096386981}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/PlayScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/PlayScreen.prefab
@@ -169,8 +169,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -120, y: 200}
-  m_SizeDelta: {x: 220, y: 40}
+  m_AnchoredPosition: {x: -120, y: 159}
+  m_SizeDelta: {x: 200, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4224587864108413799
 CanvasRenderer:
@@ -366,7 +366,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 220, y: 40}
+  m_SizeDelta: {x: 200, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1484606777777913390
 CanvasRenderer:
@@ -396,7 +396,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Connection Status
+  m_text: Serial Connection
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -423,8 +423,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 24
-  m_fontSizeBase: 24
+  m_fontSize: 20
+  m_fontSizeBase: 20
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -888,6 +888,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   resetRampButton: {fileID: 6748951209935578255}
   randomBallButton: {fileID: 0}
+  serialStatusIndicator: {fileID: 280350794043064211}
 --- !u!1 &7973036634516842441
 GameObject:
   m_ObjectHideFlags: 0

--- a/Boccia-Unity/Assets/Boccia/UI/RampSetupPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/RampSetupPresenter.cs
@@ -60,7 +60,7 @@ public class RampSetupPresenter : MonoBehaviour
         recalibrateRotationButton.onClick.AddListener(CalibrationHandler);
 
         // Start with done button enabled until calibration done
-        doneButton.interactable = false;
+        doneButton.interactable = !calibrationNeeded;
 
         // Disable calibration buttons on start
         EnableCalibrateButtons(false);
@@ -75,8 +75,6 @@ public class RampSetupPresenter : MonoBehaviour
 
         // Set all calibration checks to false
         ResetCalibrationStatus();
-
-        if (!calibrationNeeded) { doneButton.interactable = true; }
     }
 
     // TODO: add functionality to the buttons
@@ -89,6 +87,12 @@ public class RampSetupPresenter : MonoBehaviour
         // {
         //    Debug.Log( _model.ReadSerialCommand() );
         // }
+    }
+
+    void OnEnable()
+    {
+        // Check connection status to update label when panel is enabled
+        CheckConnectionStatus();
     }
 
     public void PopulateSerialPortDropdown()
@@ -127,6 +131,27 @@ public class RampSetupPresenter : MonoBehaviour
                 ConnectToSerialPort();
                 break;
         }
+    }
+
+    private void CheckConnectionStatus()
+    {
+        if (_model.HardwareSettings.IsSerialPortConnected)
+        {
+            connectSerialPortButton.GetComponentInChildren<TextMeshProUGUI>().text = "Disconnect";
+            connectSerialPortButton.GetComponent<Image>().color = Color.red;
+            serialPortDropdown.enabled = false;
+            EnableCalibrateButtons(true);
+        }
+        else
+        {
+            connectSerialPortButton.GetComponentInChildren<TextMeshProUGUI>().text = "Connect";
+            connectSerialPortButton.GetComponent<Image>().color = Color.green;
+            serialPortDropdown.enabled = true;
+            EnableCalibrateButtons(false);
+        }
+
+        // Enable or disable done button based on whether calibration is needed
+        doneButton.interactable = !calibrationNeeded;
     }
 
     private void ConnectToSerialPort()
@@ -172,7 +197,7 @@ public class RampSetupPresenter : MonoBehaviour
             connectSerialPortButton.GetComponentInChildren<TextMeshProUGUI>().text = "Connect";
             connectSerialPortButton.GetComponent<Image>().color = Color.green;
             serialPortDropdown.enabled = true;
-            doneButton.interactable = false;
+            if (calibrationNeeded) { doneButton.interactable = false; }
             _rampIsCalibrating = false;
             EnableCalibrateButtons(false);
             ResetCalibrationStatus();
@@ -294,7 +319,7 @@ public class RampSetupPresenter : MonoBehaviour
 
     private void ResetCalibrationStatus()
     {
-        doneButton.interactable = false;
+        if (calibrationNeeded) { doneButton.interactable = false; }
 
         // In case there are no motors to calibrate, reset all motors
         bool reset_all = false;


### PR DESCRIPTION
[BOC-129:](https://bci4kids.atlassian.net/browse/BOC-129?atlOrigin=eyJpIjoiYmFkZDZkNDJkZjk4NGNiZDk3NGI4ZjY5MTE4NjUyZDciLCJwIjoiaiJ9) Status indicator for serial connection

- Added a UI element to the Play screen to act as the status indicator
- When in Play mode, `PlayScreenPresenter.cs` runs a coroutine to check the serial port connection - it checks every 6 seconds to minimize computational load. The coroutine stops when the user navigates away from the play screen.
- If the connection status changed since the last check, it updates the indicator's text and colour.

Testing:
- You will need the Arduino to test the serial connection.
- Navigate to the Play Menu. In the Ramp Setup screen, select the Arduino's COM port from the dropdown and press Connect.
- Click Done to proceed to the Play screen. The indicator should be green and say "Serial Connected"
- Unplug the Arduino. Within ~6 seconds, the indicator should change to red and say "Serial Disconnected"
- The screen will switch back to show the ramp setup menu so that you can reset the connection.
- To verify that the coroutine only runs while in Play mode, you can uncomment the  "Checking serial connection" debug log in the `CheckSerialPortConnection()` coroutine in `PlayScreenPresenter.cs`. That debug log will be called every 6 seconds while in Play screen, but it should stop if you navigate to any other screen.