### PR TITLE
Fix the bug where the court view obscures the fan

### DIFF
--- a/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
@@ -114,11 +114,6 @@ public class VirtualPlayPresenter : MonoBehaviour
         {
             // Disable camera
             VirtualPlayCamera.gameObject.SetActive(false);
-
-            // Allow virtual play buttons and fan to be interactable
-            ToggleVirtualPlayButtons(true);
-            ToggleFan(true);
-
             isCourtViewOn = false;
         }
 
@@ -126,11 +121,6 @@ public class VirtualPlayPresenter : MonoBehaviour
         {
             // Enable camera
             VirtualPlayCamera.gameObject.SetActive(true);
-
-            // Prevent virtual play buttons and fan from being interactable
-            ToggleVirtualPlayButtons(false);
-            ToggleFan(false);
-
             isCourtViewOn = true;
         }
     }

--- a/Boccia-Unity/Assets/Boccia/World/VirtualPlayCamera.prefab
+++ b/Boccia-Unity/Assets/Boccia/World/VirtualPlayCamera.prefab
@@ -62,11 +62,11 @@ Camera:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 0.45
-    height: 0.75
+    width: 0.4
+    height: 0.4
   near clip plane: 0.3
   far clip plane: 1000
-  field of view: 60
+  field of view: 30
   orthographic: 0
   orthographic size: 5
   m_Depth: 0

--- a/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
+++ b/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
@@ -3765,19 +3765,19 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 8042703545872246154, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: field of view
-      value: 58.9
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.1
+      value: 0.99
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.08
+      value: 0.05
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 16.09
+      value: 15.44
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalRotation.w

--- a/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
+++ b/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
@@ -366,7 +366,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1638828288303969560, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
       propertyPath: m_Value
-      value: 29.5
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 1638828288303969560, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
       propertyPath: m_MaxValue
@@ -414,7 +414,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4537534951723010529, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
       propertyPath: m_Value
-      value: 68.3
+      value: 68
       objectReference: {fileID: 0}
     - target: {fileID: 4537534951723010529, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
       propertyPath: m_MaxValue
@@ -578,7 +578,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8550961515427245145, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
       propertyPath: m_Value
-      value: 2.77
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 8550961515427245145, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
       propertyPath: m_MaxValue
@@ -3763,37 +3763,41 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 8042703545872246154, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
+      propertyPath: field of view
+      value: 58.9
+      objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 4.71
+      value: 0.1
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 7.9
+      value: 0.08
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 14.54
+      value: 16.09
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.9292643
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.36941555
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 43.359
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8216061330022203258, guid: 4709d4f0887c783479110c4deab2b320, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y


### PR DESCRIPTION
[BOC-134](https://bci4kids.atlassian.net/browse/BOC-134?atlOrigin=eyJpIjoiYTRiYTM3OGUyZDc2NDA0NmE0ZDY1MDk5NmUwODdiZGYiLCJwIjoiaiJ9): Court view obscures the fan

The problem was that the court view in **Virtual Play** covered up part of the fan, and the fan segments and the other virtual play buttons could not be selected while the court view was toggled on. Also, the bird's-eye view of the camera may not be the most intuitive for the user.

Changes:
- Changed the size of the court view display to be smaller and less obstructive to the rest of the screen.
- Repositioned the camera so that it more closely resembles the perspective of the Boccia player from behind the ramp, rather than the bird's-eye view.
- Modified `VirtualPlayPresenter` so that the buttons and the fan can now be selected when the court view is on. 