### PR TITLE
Display the coarse fan when the ramp is reset

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
@@ -38,6 +38,7 @@ public class FanPresenter : MonoBehaviour
         _model = BocciaModel.Instance; 
         _model.NavigationChanged += NavigationChanged;
         _model.WasChanged += UpdateFineFan;
+        _model.ResetFan += ResetFanWhenRampResets;
 
         _originalRotation = transform.rotation;  
 
@@ -207,6 +208,15 @@ public class FanPresenter : MonoBehaviour
         {
             positioningMode = FanPositioningMode.CenterToBase;
             _lastPlayMode = currentPlayMode;
+        }
+    }
+
+    private void ResetFanWhenRampResets()
+    {
+        if (positioningMode == FanPositioningMode.CenterToRails)
+        {
+            positioningMode = FanPositioningMode.CenterToBase;
+            GenerateFanWorkflow();
         }
     }
 

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -64,6 +64,7 @@ public class BocciaModel : Singleton<BocciaModel>
     public event System.Action NewRandomJack;
     public event System.Action BallResetChanged;
     public event System.Action BallFallingChanged;
+    public event System.Action ResetFan;
 
     // Hardware interface
     // TODO - create this based on game mode (live or sim)
@@ -246,6 +247,11 @@ public class BocciaModel : Singleton<BocciaModel>
     public void HandleBallFalling()
     {
         SendBallFallingEvent();
+    }
+
+    public void ResetFanWhenRampResets()
+    {
+        SendFanResetEvent();
     }
 
     public void ResetVirtualBalls()
@@ -468,6 +474,11 @@ public class BocciaModel : Singleton<BocciaModel>
     private void SendBallFallingEvent()
     {
         BallFallingChanged?.Invoke();
+    }
+
+    private void SendFanResetEvent()
+    {
+        ResetFan?.Invoke();
     }
 
     // MARK: Resetting states to Defaults

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -19,6 +19,10 @@ public class PlayScreenPresenter : MonoBehaviour
     private int _randomRotation;
     private int _randomElevation;
 
+    [SerializeField]
+    // Set to false for development mode, true for production mode
+    private bool _arduinoIsNeeded = false;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -46,7 +50,7 @@ public class PlayScreenPresenter : MonoBehaviour
         _model.WasChanged += ModelChanged;
         _model.NavigationChanged += NavigationChanged;
 
-        if (_model.GameMode == BocciaGameMode.Play)
+        if (_model.GameMode == BocciaGameMode.Play && _arduinoIsNeeded)
         {
             _checkSerialCoroutine = StartCoroutine(CheckSerialPortConnection());
         }

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -19,7 +19,7 @@ public class PlayScreenPresenter : MonoBehaviour
         _model = BocciaModel.Instance;
 
         // connect buttons to model
-        resetRampButton.onClick.AddListener(_model.ResetRampPosition);
+        resetRampButton.onClick.AddListener(ResetRamp);
         randomBallButton.onClick.AddListener(SetRandomBallDropPosition);
         
         // TODO: see task BOC-90 for what the random ball button should do
@@ -72,5 +72,11 @@ public class PlayScreenPresenter : MonoBehaviour
 
         _model.ResetRampPosition();
 
+    }
+
+    private void ResetRamp()
+    {
+        _model.ResetRampPosition();
+        _model.ResetFanWhenRampResets();
     }
 }

--- a/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
@@ -56,7 +56,7 @@ public class VirtualPlayPresenter : MonoBehaviour
         rotateRightButton.onClick.AddListener(RotateRight);
         moveUpButton.onClick.AddListener(MoveUp);
         moveDownButton.onClick.AddListener(MoveDown);
-        resetRampButton.onClick.AddListener(model.ResetRampPosition);
+        resetRampButton.onClick.AddListener(ResetRamp);
         resetBallButton.onClick.AddListener(model.ResetVirtualBalls);
         dropBallButton.onClick.AddListener(model.DropBall);
         colorButton.onClick.AddListener(model.RandomBallColor);
@@ -104,6 +104,12 @@ public class VirtualPlayPresenter : MonoBehaviour
     private void MoveDown()
     {
         model.ElevateBy(-1.0f);
+    }
+
+    private void ResetRamp()
+    {
+        model.ResetRampPosition();
+        model.ResetFanWhenRampResets();
     }
 
     private void ToggleCamera()


### PR DESCRIPTION
[BOC-135](https://bci4kids.atlassian.net/browse/BOC-135?atlOrigin=eyJpIjoiYjBkM2NhMTI5NThhNDEyOWJmMjA5YTg5M2ZjZmE3MmQiLCJwIjoiaiJ9): When reset ramp is pressed, the coarse fan should be displayed.

The problem: when the Reset Ramp button was pressed, the ramp would move back to its default position, but the fine fan from the last adjustment would remain where it was. To get back to the coarse fan, you had to select the fan's back button.

Changes:

- The Reset Ramp button in both Virtual Play and Play mode uses an event action to trigger a new method in `FanPresenter.cs` called `ResetFanWhenRampResets()`. 
- This method switches back to the coarse fan. The old fan disappears when the ramp is moved, and the coarse fan is displayed once the ramp stops moving.

Testing:
- Navigate to Virtual Play and/or Play and move the ramp. 
- Press the Reset Ramp button. You should see that the coarse fan appears once the ramp resets to its initial position. This works even if you don't wait for the fan to stop moving before clicking Reset. 