### PR TITLE
100-ramp-limits

### DIFF
--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO.Ports;
 using UnityEngine;
@@ -8,12 +9,24 @@ public class HardwareRamp : RampController, ISerialController
 {
     public event Action RampChanged;
 
-    public float Rotation { get; private set; }
-    private float MaxRotation { get; } = 85.0f;
-    private float MinRotation { get; } = -85.0f;
-    public float Elevation { get; private set; }
-    private float MaxElevation { get;} = 100.0f;
-    private float MinElevation { get; } = 0.0f;
+    private float _minRotation = -85.0f;
+    private float _maxRotation = 85.0f;
+    private float _rotation;
+    public float Rotation 
+    { 
+        get { return _rotation; } 
+        set { _rotation = Math.Clamp(value, _minRotation, _maxRotation); }
+    }
+
+    private float _maxElevation = 100.0f;
+    private float _minElevation = 0.0f;
+    private float _elevation;
+    public float Elevation
+    { 
+        get {return _elevation; }
+        set { _elevation = Math.Clamp(value, _minElevation, _maxElevation); }
+    }
+
     public bool IsBarOpen { get; private set;}
     public bool IsMoving { get; set; }
 
@@ -35,8 +48,8 @@ public class HardwareRamp : RampController, ISerialController
 
     public void RotateBy(float degrees)
     {
-        // Rotation += degrees;
-        Rotation = Mathf.Clamp(Rotation+degrees, MinRotation, MaxRotation);
+        Rotation += degrees;
+        // Rotation = Mathf.Clamp(Rotation+degrees, _minRotation, _maxRotation);
         AddSerialCommandToList($"rr{degrees}");
         // Debug.Log($"Hardware rote by: {Rotation}");
         SendChangeEvent();
@@ -44,19 +57,19 @@ public class HardwareRamp : RampController, ISerialController
 
     public void RotateTo(float degrees)
     {
-        // Rotation = degrees;
-        Rotation = Mathf.Clamp(degrees, MinRotation, MaxRotation);
+        Rotation = degrees;
+        // Rotation = Mathf.Clamp(degrees, MinRotation, MaxRotation);
         AddSerialCommandToList($"ra{degrees}");
-        // Debug.Log($"Hardware rote to: {Rotation}");
+        Debug.Log($"Hardware rotate to: {Rotation}");
         SendChangeEvent();
     }
 
     public void ElevateBy(float elevation)
     {
         //Old Way
-        // Elevation += elevation;
+        Elevation += elevation;
         // Clamped to Max/Min Elevation
-        Elevation = Mathf.Clamp(Elevation + elevation, MinElevation, MaxElevation);
+        // Elevation = Mathf.Clamp(Elevation + elevation, _minElevation, _maxElevation);
         AddSerialCommandToList($"er{elevation}");
         // Debug.Log($"Hardware elevate by: {Elevation}");
         SendChangeEvent();
@@ -65,9 +78,9 @@ public class HardwareRamp : RampController, ISerialController
     public void ElevateTo(float elevation)
     {
         //Old Way
-        // Elevation = elevation;
+        Elevation = elevation;
         // Clamped to Max/Min Elevation
-        Elevation = Mathf.Clamp(elevation, MinElevation, MaxElevation);
+        // Elevation = Mathf.Clamp(elevation, _minElevation, _maxElevation);
         AddSerialCommandToList($"ea{elevation}");
         // Debug.Log($"Hardware elevate to: {Elevation}");
         SendChangeEvent();

--- a/Boccia-Unity/Assets/Boccia/Model/SimulatedRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/SimulatedRamp.cs
@@ -12,12 +12,24 @@ public class SimulatedRamp : RampController
 {
     public event System.Action RampChanged;
 
-    public float Rotation { get; private set; }
-    private float MaxRotation { get; } = 85.0f;
-    private float MinRotation { get; } = -85.0f;
-    public float Elevation { get; private set; }
-    private float MaxElevation { get;} = 100.0f;
-    private float MinElevation { get; } = 0.0f;
+    private float _minRotation = -85.0f;
+    private float _maxRotation = 85.0f;
+    private float _rotation;
+    public float Rotation 
+    { 
+        get { return _rotation; } 
+        set { _rotation = Math.Clamp(value, _minRotation, _maxRotation); }
+    }
+
+    private float _maxElevation = 100.0f;
+    private float _minElevation = 0.0f;
+    private float _elevation;
+    public float Elevation
+    { 
+        get {return _elevation; }
+        set { _elevation = Math.Clamp(value, _minElevation, _maxElevation); }
+    }
+
     public bool IsBarOpen { get; private set;}
     public bool IsMoving { get; set; }
 
@@ -31,30 +43,28 @@ public class SimulatedRamp : RampController
 
     public void RotateBy(float degrees)
     {
-        // Rotation += degrees;
-        Rotation = Mathf.Clamp(Rotation+degrees, MinRotation, MaxRotation);
+        Rotation += degrees;
         //Debug.Log($"Simulated rotation by: {Rotation}");
         SendChangeEvent();
     }
 
     public void RotateTo(float degrees)
     {
-        // Rotation = degrees;
-        Rotation = Mathf.Clamp(degrees, MinRotation, MaxRotation);
+        Rotation = degrees;
         //Debug.Log($"Simulated rotation to: {Rotation}");
         SendChangeEvent();
     }
 
     public void ElevateBy(float elevation)
     {
-        Elevation = Mathf.Clamp(Elevation + elevation, MinElevation, MaxElevation);
+        Elevation += elevation;
         //Debug.Log($"Simulated elevation by: {Elevation}");
         SendChangeEvent();
     }
 
     public void ElevateTo(float elevation)
     {
-        Elevation = Mathf.Clamp(elevation, MinElevation, MaxElevation);
+        Elevation = elevation;
         // Debug.Log($"Simulated elevation to: {Elevation}");
         SendChangeEvent();
     }

--- a/Boccia-Unity/Assets/Boccia/Model/SimulatedRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/SimulatedRamp.cs
@@ -14,22 +14,18 @@ public class SimulatedRamp : RampController
 
     private BocciaModel _model;
 
-    private float _minRotation = -85.0f;
-    private float _maxRotation = 85.0f;
     private float _rotation;
     public float Rotation 
     { 
         get { return _rotation; } 
-        set { _rotation = Math.Clamp(value, _minRotation, _maxRotation); }
+        set { _rotation = Math.Clamp(value, _model.RampSettings.RotationLimitMin, _model.RampSettings.RotationLimitMax); }
     }
 
-    private float _maxElevation = 100.0f;
-    private float _minElevation = 0.0f;
     private float _elevation;
     public float Elevation
     { 
         get {return _elevation; }
-        set { _elevation = Math.Clamp(value, _minElevation, _maxElevation); }
+        set { _elevation = Math.Clamp(value, _model.RampSettings.ElevationLimitMin, _model.RampSettings.ElevationLimitMax); }
     }
 
     public bool IsBarOpen { get; private set;}
@@ -59,14 +55,14 @@ public class SimulatedRamp : RampController
         SendChangeEvent();
     }
 
-    public void ElevateBy(float height)
+    public void ElevateBy(float elevation)
     {
         Elevation += elevation;
         //Debug.Log($"Simulated elevation by: {Elevation}");
         SendChangeEvent();
     }
 
-    public void ElevateTo(float height)
+    public void ElevateTo(float elevation)
     {
         Elevation = elevation;
         // Debug.Log($"Simulated elevation to: {Elevation}");

--- a/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
@@ -89,9 +89,9 @@ public class RampPresenter : MonoBehaviour
     {
         // Smoothly show the rotatation of the ramp to the new position
         Quaternion currentRotation = rotationShaft.transform.localRotation;
-        Debug.Log("Current Rotation: " + currentRotation.eulerAngles);
+        // Debug.Log("Current Rotation: " + currentRotation.eulerAngles);
         Quaternion targetQuaternion = Quaternion.Euler(rotationShaft.transform.localEulerAngles.x, _model.RampRotation, rotationShaft.transform.localEulerAngles.z);
-        Debug.Log($"model.RampRotation value: {_model.RampRotation}");
+        // Debug.Log($"model.RampRotation value: {_model.RampRotation}");
 
         while (Quaternion.Angle(currentRotation, targetQuaternion) > 0.01f)
         {

--- a/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
@@ -12,8 +12,9 @@ public class RampPresenter : MonoBehaviour
     public GameObject elevationMechanism; // Elevation Mechanism child component of Shaft and Ramp (the ramp parts that will change elevation in the visualization)
     public GameObject rampAdapter; // To define direction of movement for elevationMechanism
 
-    public float minElevation = 0.0026f; 
-    public float maxElevation = 0.43f; 
+    // Max values for animation
+    private float _minElevation = 0.0026f; 
+    private float _maxElevation = 0.43f; 
 
     private BocciaModel _model;
 
@@ -88,9 +89,9 @@ public class RampPresenter : MonoBehaviour
     {
         // Smoothly show the rotatation of the ramp to the new position
         Quaternion currentRotation = rotationShaft.transform.localRotation;
-        //Debug.Log("Current Rotation: " + currentRotation.eulerAngles);
+        Debug.Log("Current Rotation: " + currentRotation.eulerAngles);
         Quaternion targetQuaternion = Quaternion.Euler(rotationShaft.transform.localEulerAngles.x, _model.RampRotation, rotationShaft.transform.localEulerAngles.z);
-        //Debug.Log($"model.RampRotation value: {model.RampRotation}");
+        Debug.Log($"model.RampRotation value: {_model.RampRotation}");
 
         while (Quaternion.Angle(currentRotation, targetQuaternion) > 0.01f)
         {
@@ -105,11 +106,10 @@ public class RampPresenter : MonoBehaviour
     private IEnumerator ElevationVisualization()
     {
         Vector3 currentElevation = elevationMechanism.transform.localPosition;
-        //Debug.Log($"model.RampElevation value: {model.RampElevation}");
-        float elevationScalar = minElevation + (_model.RampElevation / 100f) * (maxElevation - minElevation); // Convert percent elevation to its scalar value
+        float elevationScalar = _minElevation + (_model.RampElevation / 100f) * (_maxElevation - _minElevation); // Convert percent elevation to its scalar value
         
         //Make sure the elevation is within the min and max elevation bounds
-        elevationScalar = Mathf.Clamp(elevationScalar, minElevation, maxElevation);
+        elevationScalar = Mathf.Clamp(elevationScalar, _minElevation, _maxElevation);
 
         Vector3 targetElevation = elevationDirection * elevationScalar;   
         


### PR DESCRIPTION
Implementation:
- Modified the `HardwareRamp` and `SimulatedRamp` so that clamping happens only once when setting `Rotation` and `Elevation` values. The clamping limits are pulled from the `_model.RampSettings`.
- Added flags in `HardwareRamp` to know if the `Rotation` or `Elevation` values were clamped. If so, the relative movements (i.e., `RotateBy`, `ElevateBy`) are set to 0 in the serial port.

Testing
- Uncomment debug lines in the `Rotate...` and `Elevate...` methods in `HardwareRamp` and `SimulatedRamp`.
- The ramp should clamp to the values set in the `model` (lines 165-168). You can modify this values to test correct functioning.

Notes
- There might be a bug where the coarseFan does not display correctly because the `Theta` and `ElevationRange` values are overwritten on the first run. Run the software, select `Project/Assets/Boccia/BCI/CoarseFanSettings` and manually change the values to 160 and 100, respectively. Re run and it should be fine. I will address this bug later, it is already documented