### PR TITLE
122-mapping-speeds

### DIFF
--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -225,8 +225,8 @@ public class BocciaModel : Singleton<BocciaModel>
         bocciaData.GameOptions.RotationRange = 20;
 
         // Operator values
-        bocciaData.GameOptions.ElevationSpeed = 50; // Range from 1 to 100%
-        bocciaData.GameOptions.RotationSpeed = 50;  // Range from 1 to 100%
+        bocciaData.GameOptions.ElevationSpeed = 500; // 50% of max speed
+        bocciaData.GameOptions.RotationSpeed = 127;  // 50% of max speed
 
         // Note: SendRampChangeEvent() trigged within ResetGameOptionsToDefaults();
     }

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -213,6 +213,9 @@ public class BocciaModel : Singleton<BocciaModel>
     public void ElevateBy(float elevation) => rampController.ElevateBy(elevation);
     public void ElevateTo(float elevation) => rampController.ElevateTo(elevation);
 
+    public float ScaleRotationSpeed(float speed) => _hardwareRamp.ScaleRotationSpeed(speed);
+    public float ScaleElevationSpeed(float speed) => _hardwareRamp.ScaleElevationSpeed(speed);
+
     public void ResetRampPosition() => rampController.ResetRampPosition();
 
     public void DropBall() => rampController.DropBall();

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -163,8 +163,8 @@ public class BocciaModel : Singleton<BocciaModel>
         bocciaData.GameOptions.RotationRange = 20;
 
         // Operator values
-        bocciaData.GameOptions.ElevationSpeed = 5;
-        bocciaData.GameOptions.RotationSpeed = 5;
+        bocciaData.GameOptions.ElevationSpeed = 50; // Range from 1 to 100%
+        bocciaData.GameOptions.RotationSpeed = 50;  // Range from 1 to 100%
 
         // Note: SendRampChangeEvent() trigged within ResetGameOptionsToDefaults();
     }

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -225,8 +225,8 @@ public class BocciaModel : Singleton<BocciaModel>
         bocciaData.GameOptions.RotationRange = 20;
 
         // Operator values
-        bocciaData.GameOptions.ElevationSpeed = 500; // 50% of max speed
-        bocciaData.GameOptions.RotationSpeed = 127;  // 50% of max speed
+        bocciaData.GameOptions.ElevationSpeed = 127; // 50% of max speed
+        bocciaData.GameOptions.RotationSpeed = 500;  // 50% of max speed
 
         // Note: SendRampChangeEvent() trigged within ResetGameOptionsToDefaults();
     }

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -225,8 +225,8 @@ public class BocciaModel : Singleton<BocciaModel>
         bocciaData.GameOptions.RotationRange = 20;
 
         // Operator values
-        bocciaData.GameOptions.ElevationSpeed = 127; // 50% of max speed
-        bocciaData.GameOptions.RotationSpeed = 500;  // 50% of max speed
+        bocciaData.GameOptions.ElevationSpeed = bocciaData.RampSettings.ElevationSpeedMax;
+        bocciaData.GameOptions.RotationSpeed = bocciaData.RampSettings.RotationSpeedMax;
 
         // Note: SendRampChangeEvent() trigged within ResetGameOptionsToDefaults();
     }

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -85,14 +85,17 @@ public class HardwareRamp : RampController, ISerialController
         float stepsPerRevolution = 800f;        // Steps per revolution: 800 steps/rev
         float RotationMotorMaxSpeed = 1000f;    // Max speed: 1000 steps/sec according to AccelStepper library
         float gearRatio = 3f;                   // Gear ratio: 3:1
-        float scaledSpeed = (speed / 100f) * (RotationMotorMaxSpeed / stepsPerRevolution / gearRatio);
+        float speedPercentage = speed / (_model.RampSettings.RotationSpeedMax - _model.RampSettings.RotationSpeedMin);
+        float scaledSpeed = speedPercentage * (RotationMotorMaxSpeed / stepsPerRevolution / gearRatio);
         return scaledSpeed;
     }
 
     public float ScaleElevationSpeed(float speed)
     {
         float elevationMotorMaxSpeed = 2.0f;    // Max speed: 2 inches/sec at 35 lbs
-        float scaledSpeed = (speed / 100f) * elevationMotorMaxSpeed;
+        float rampScaling = 3;                  // Scaling factor: 3 from the Boccia ramp model in the scene
+        float speedPercentage = speed / (_model.RampSettings.ElevationSpeedMax - _model.RampSettings.ElevationSpeedMin);
+        float scaledSpeed = speedPercentage * elevationMotorMaxSpeed / rampScaling;
         return scaledSpeed;
     }
 

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -82,6 +82,22 @@ public class HardwareRamp : RampController, ISerialController
         SendChangeEvent();
     }
 
+    public float ScaleRotationSpeed(float speed)
+    {
+        float stepsPerRevolution = 800f;        // Steps per revolution: 800 steps/rev
+        float RotationMotorMaxSpeed = 1000f;    // Max speed: 1000 steps/sec according to AccelStepper library
+        float gearRatio = 3f;                   // Gear ratio: 3:1
+        float scaledSpeed = (speed / 100f) * (RotationMotorMaxSpeed / stepsPerRevolution / gearRatio);
+        return scaledSpeed;
+    }
+
+    public float ScaleElevationSpeed(float speed)
+    {
+        float elevationMotorMaxSpeed = 2.0f;    // Max speed: 2 inches/sec at 35 lbs
+        float scaledSpeed = (speed / 100f) * elevationMotorMaxSpeed;
+        return scaledSpeed;
+    }
+
     public void RandomBallDrop(int randomRotation, int randomElevation)
     {
         RotateTo(randomRotation);

--- a/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
@@ -19,7 +19,7 @@ public class RampPresenter : MonoBehaviour
 
     [SerializeField] private float _elevationSpeed;
     [SerializeField] private float _rotationSpeed;
-
+    
     private Vector3 elevationDirection; // Vector to define the direction of motion of the elevationMechanism visualization
 
     private BocciaGameMode _lastPlayMode;
@@ -86,7 +86,7 @@ public class RampPresenter : MonoBehaviour
 
     private IEnumerator RotationVisualization()
     {
-        // Smoothly show the rotatation of the ramp to the new position
+        // Smoothly show the rotation of the ramp to the new position
         Quaternion currentRotation = rotationShaft.transform.localRotation;
         //Debug.Log("Current Rotation: " + currentRotation.eulerAngles);
         Quaternion targetQuaternion = Quaternion.Euler(rotationShaft.transform.localEulerAngles.x, _model.RampRotation, rotationShaft.transform.localEulerAngles.z);
@@ -94,7 +94,8 @@ public class RampPresenter : MonoBehaviour
 
         while (Quaternion.Angle(currentRotation, targetQuaternion) > 0.01f)
         {
-            currentRotation = Quaternion.Lerp(currentRotation, targetQuaternion, _rotationSpeed * Time.deltaTime);
+            float scaledSpeed = _model.ScaleRotationSpeed(_rotationSpeed);
+            currentRotation = Quaternion.Lerp(currentRotation, targetQuaternion, scaledSpeed * Time.deltaTime);
             rotationShaft.transform.localRotation = currentRotation;
             yield return null;
         }
@@ -115,7 +116,10 @@ public class RampPresenter : MonoBehaviour
         
         while (Vector3.Distance(currentElevation, targetElevation) > 0.001f)
         {
-            currentElevation = Vector3.Lerp(currentElevation, targetElevation, _elevationSpeed * Time.deltaTime);
+            // Calculate the scaled speed for elevation
+            // Max speed: 2 inches/sec
+            float scaledSpeed = _model.ScaleElevationSpeed(_elevationSpeed);
+            currentElevation = Vector3.Lerp(currentElevation, targetElevation, scaledSpeed * Time.deltaTime);
             elevationMechanism.transform.localPosition = currentElevation;
             yield return null;
         }

--- a/Boccia-Unity/Assets/Boccia/UI/RampSetupPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/RampSetupPresenter.cs
@@ -41,6 +41,7 @@ public class RampSetupPresenter : MonoBehaviour
     {
         // cache model
         _model = BocciaModel.Instance;
+        _model.NavigationChanged += NavigationChanged;
 
         // Connect buttons to model
         closeButton.onClick.AddListener(_model.PlayMenu);
@@ -89,10 +90,12 @@ public class RampSetupPresenter : MonoBehaviour
         // }
     }
 
-    void OnEnable()
+    void NavigationChanged()
     {
-        // Check connection status to update label when panel is enabled
-        CheckConnectionStatus();
+        if (_model.CurrentScreen == BocciaScreen.RampSetup)
+        {
+            CheckConnectionStatus();
+        }        
     }
 
     public void PopulateSerialPortDropdown()

--- a/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
+++ b/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
@@ -389,12 +389,20 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2477273195012389994, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2477273195012389994, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2695175203650030251, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2924849139167696035, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
+      propertyPath: m_MaxValue
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 3095787491283501321, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
       propertyPath: m_AnchorMax.x
@@ -525,7 +533,15 @@ PrefabInstance:
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6092222662226599349, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6092222662226599349, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
       propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6092222662226599349, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
+      propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6164881059010123498, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
@@ -563,6 +579,14 @@ PrefabInstance:
     - target: {fileID: 8419566006404413373, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8491921247395821542, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
+      propertyPath: m_Value
+      value: 49.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 8491921247395821542, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
+      propertyPath: m_MaxValue
+      value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 8533241150640456240, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
       propertyPath: m_AnchorMax.x


### PR DESCRIPTION
Implementation
- Added `ScaleRotationSpeed` and `ScaleElevationSpeed` methods to `HardwareRamp`. These methods implement scaling by using values of the hardwareRamp. The methods are called in the `RampPresenter` so that the vitual ramp matches the speed of the hardware one.

Testing
- Select virtual or play mode and move the ramp, it should move much slower, similar to the real ramp.
- Modify the speed values in game options and test accordingly.

Note
- Ideally we should compare the speed with the actual ramp, but the hardware ramp is now waiting for some parts so further testing should be done later.