### PR TITLE
145-BCI-selection

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanInteractions.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanInteractions.cs
@@ -59,8 +59,10 @@ public class FanInteractions : MonoBehaviour, IPointerClickHandler
 
             spo.StartStimulusEvent.AddListener(() => child.GetComponent<ColorFlashEffect>().SetOn());
             spo.StopStimulusEvent.AddListener(() => child.GetComponent<ColorFlashEffect>().SetOff());
+
             spo.OnSelectedEvent.AddListener(() => child.GetComponent<SPO>().StopStimulus());
-            spo.OnSelectedEvent.AddListener(() => child.GetComponent<ColorFlashEffect>().Play());                
+            spo.OnSelectedEvent.AddListener(() => child.GetComponent<ColorFlashEffect>().Play());            
+            spo.OnSelectedEvent.AddListener(() => OnSegmentClick(child.transform));                
 
             segmentID++;
         }

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/PlayScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/PlayScreen.prefab
@@ -222,9 +222,11 @@ GameObject:
   - component: {fileID: 491917470012584253}
   - component: {fileID: 4869450835517760207}
   - component: {fileID: 6748951209935578255}
+  - component: {fileID: 1105981148811745135}
+  - component: {fileID: 6277914520999626746}
   m_Layer: 6
   m_Name: ResetRampButton
-  m_TagString: Untagged
+  m_TagString: BCI
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -331,6 +333,93 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &1105981148811745135
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1087478738280944160}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7720a1dc0ec4493980b36fef8105f94a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _renderer: {fileID: 0}
+  _flashOnColor: {r: 1, g: 0, b: 0, a: 1}
+  _flashOffColor: {r: 1, g: 1, b: 1, a: 1}
+  _startOn: 0
+  _flashDurationSeconds: 0.2
+  _flashAmount: 3
+--- !u!114 &6277914520999626746
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1087478738280944160}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58dafbcfd2f661d438f57f8ab612995a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  StartStimulusEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1105981148811745135}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials.Runtime
+        m_MethodName: SetOn
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  StopStimulusEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1105981148811745135}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials.Runtime
+        m_MethodName: SetOff
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  OnSelectedEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1105981148811745135}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials.Runtime
+        m_MethodName: Play
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  StartTrainingStimulusEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  StopTrainingStimulusEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  Selectable: 1
+  SelectablePoolIndex: 0
+  ObjectID: 0
 --- !u!1 &2136889402653620579
 GameObject:
   m_ObjectHideFlags: 0
@@ -732,9 +821,11 @@ GameObject:
   - component: {fileID: 7781101804396931157}
   - component: {fileID: 3243721716787812892}
   - component: {fileID: 3214086637462062914}
+  - component: {fileID: 5248662472936413055}
+  - component: {fileID: 8358808418726444481}
   m_Layer: 6
   m_Name: RandomBallButton
-  m_TagString: Untagged
+  m_TagString: BCI
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -841,6 +932,93 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &5248662472936413055
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3915093870228750941}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7720a1dc0ec4493980b36fef8105f94a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _renderer: {fileID: 0}
+  _flashOnColor: {r: 1, g: 0, b: 0, a: 1}
+  _flashOffColor: {r: 1, g: 1, b: 1, a: 1}
+  _startOn: 0
+  _flashDurationSeconds: 0.2
+  _flashAmount: 3
+--- !u!114 &8358808418726444481
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3915093870228750941}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58dafbcfd2f661d438f57f8ab612995a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  StartStimulusEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5248662472936413055}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials.Runtime
+        m_MethodName: SetOn
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  StopStimulusEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5248662472936413055}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials.Runtime
+        m_MethodName: SetOff
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  OnSelectedEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5248662472936413055}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials.Runtime
+        m_MethodName: Play
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  StartTrainingStimulusEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  StopTrainingStimulusEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  Selectable: 1
+  SelectablePoolIndex: 0
+  ObjectID: 37
 --- !u!1 &7062422457744525498
 GameObject:
   m_ObjectHideFlags: 0

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/PlayScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/PlayScreen.prefab
@@ -222,8 +222,8 @@ GameObject:
   - component: {fileID: 491917470012584253}
   - component: {fileID: 4869450835517760207}
   - component: {fileID: 6748951209935578255}
-  - component: {fileID: 1105981148811745135}
   - component: {fileID: 6277914520999626746}
+  - component: {fileID: 679174540274438189}
   m_Layer: 6
   m_Name: ResetRampButton
   m_TagString: BCI
@@ -333,24 +333,6 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
---- !u!114 &1105981148811745135
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1087478738280944160}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7720a1dc0ec4493980b36fef8105f94a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _renderer: {fileID: 0}
-  _flashOnColor: {r: 1, g: 0, b: 0, a: 1}
-  _flashOffColor: {r: 1, g: 1, b: 1, a: 1}
-  _startOn: 0
-  _flashDurationSeconds: 0.2
-  _flashAmount: 3
 --- !u!114 &6277914520999626746
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -366,9 +348,9 @@ MonoBehaviour:
   StartStimulusEvent:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1105981148811745135}
-        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
-          Bci4Kids.BciEssentials.Runtime
+      - m_Target: {fileID: 679174540274438189}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.CanvasColorFlashEffect,
+          Assembly-CSharp
         m_MethodName: SetOn
         m_Mode: 1
         m_Arguments:
@@ -382,9 +364,9 @@ MonoBehaviour:
   StopStimulusEvent:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1105981148811745135}
-        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
-          Bci4Kids.BciEssentials.Runtime
+      - m_Target: {fileID: 679174540274438189}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.CanvasColorFlashEffect,
+          Assembly-CSharp
         m_MethodName: SetOff
         m_Mode: 1
         m_Arguments:
@@ -398,9 +380,9 @@ MonoBehaviour:
   OnSelectedEvent:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1105981148811745135}
-        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
-          Bci4Kids.BciEssentials.Runtime
+      - m_Target: {fileID: 679174540274438189}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.CanvasColorFlashEffect,
+          Assembly-CSharp
         m_MethodName: Play
         m_Mode: 1
         m_Arguments:
@@ -420,6 +402,24 @@ MonoBehaviour:
   Selectable: 1
   SelectablePoolIndex: 0
   ObjectID: 0
+--- !u!114 &679174540274438189
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1087478738280944160}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 535bf50698404674ead34b338e36e3b0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _renderer: {fileID: 0}
+  _flashOnColor: {r: 1, g: 0, b: 0, a: 1}
+  _flashOffColor: {r: 1, g: 1, b: 1, a: 1}
+  _startOn: 0
+  _flashDurationSeconds: 0.2
+  _flashAmount: 3
 --- !u!1 &2136889402653620579
 GameObject:
   m_ObjectHideFlags: 0
@@ -821,8 +821,8 @@ GameObject:
   - component: {fileID: 7781101804396931157}
   - component: {fileID: 3243721716787812892}
   - component: {fileID: 3214086637462062914}
-  - component: {fileID: 5248662472936413055}
   - component: {fileID: 8358808418726444481}
+  - component: {fileID: 6438268955628440154}
   m_Layer: 6
   m_Name: RandomBallButton
   m_TagString: BCI
@@ -932,24 +932,6 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
---- !u!114 &5248662472936413055
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3915093870228750941}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7720a1dc0ec4493980b36fef8105f94a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _renderer: {fileID: 0}
-  _flashOnColor: {r: 1, g: 0, b: 0, a: 1}
-  _flashOffColor: {r: 1, g: 1, b: 1, a: 1}
-  _startOn: 0
-  _flashDurationSeconds: 0.2
-  _flashAmount: 3
 --- !u!114 &8358808418726444481
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -965,9 +947,9 @@ MonoBehaviour:
   StartStimulusEvent:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 5248662472936413055}
-        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
-          Bci4Kids.BciEssentials.Runtime
+      - m_Target: {fileID: 6438268955628440154}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.CanvasColorFlashEffect,
+          Assembly-CSharp
         m_MethodName: SetOn
         m_Mode: 1
         m_Arguments:
@@ -981,9 +963,9 @@ MonoBehaviour:
   StopStimulusEvent:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 5248662472936413055}
-        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
-          Bci4Kids.BciEssentials.Runtime
+      - m_Target: {fileID: 6438268955628440154}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.CanvasColorFlashEffect,
+          Assembly-CSharp
         m_MethodName: SetOff
         m_Mode: 1
         m_Arguments:
@@ -997,9 +979,9 @@ MonoBehaviour:
   OnSelectedEvent:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 5248662472936413055}
-        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
-          Bci4Kids.BciEssentials.Runtime
+      - m_Target: {fileID: 6438268955628440154}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.CanvasColorFlashEffect,
+          Assembly-CSharp
         m_MethodName: Play
         m_Mode: 1
         m_Arguments:
@@ -1019,6 +1001,24 @@ MonoBehaviour:
   Selectable: 1
   SelectablePoolIndex: 0
   ObjectID: 37
+--- !u!114 &6438268955628440154
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3915093870228750941}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 535bf50698404674ead34b338e36e3b0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _renderer: {fileID: 0}
+  _flashOnColor: {r: 1, g: 0, b: 0, a: 1}
+  _flashOffColor: {r: 1, g: 1, b: 1, a: 1}
+  _startOn: 0
+  _flashDurationSeconds: 0.2
+  _flashAmount: 3
 --- !u!1 &7062422457744525498
 GameObject:
   m_ObjectHideFlags: 0

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
@@ -1266,7 +1266,7 @@ GameObject:
   - component: {fileID: 3931406161124561486}
   - component: {fileID: 5591672340010151945}
   - component: {fileID: 5307156225035156463}
-  - component: {fileID: 611877319385449779}
+  - component: {fileID: 2364165486713040064}
   - component: {fileID: 3249766819828270722}
   m_Layer: 6
   m_Name: RandomJackButton
@@ -1377,7 +1377,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
---- !u!114 &611877319385449779
+--- !u!114 &2364165486713040064
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1386,10 +1386,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 4303601759080381808}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7720a1dc0ec4493980b36fef8105f94a, type: 3}
+  m_Script: {fileID: 11500000, guid: 535bf50698404674ead34b338e36e3b0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _renderer: {fileID: 0}
+  _renderer: {fileID: 3931406161124561486}
   _flashOnColor: {r: 1, g: 0, b: 0, a: 1}
   _flashOffColor: {r: 1, g: 1, b: 1, a: 1}
   _startOn: 0
@@ -1410,9 +1410,9 @@ MonoBehaviour:
   StartStimulusEvent:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 611877319385449779}
-        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
-          Bci4Kids.BciEssentials.Runtime
+      - m_Target: {fileID: 2364165486713040064}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.CanvasColorFlashEffect,
+          Assembly-CSharp
         m_MethodName: SetOn
         m_Mode: 1
         m_Arguments:
@@ -1426,9 +1426,9 @@ MonoBehaviour:
   StopStimulusEvent:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 611877319385449779}
-        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
-          Bci4Kids.BciEssentials.Runtime
+      - m_Target: {fileID: 2364165486713040064}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.CanvasColorFlashEffect,
+          Assembly-CSharp
         m_MethodName: SetOff
         m_Mode: 1
         m_Arguments:
@@ -1442,9 +1442,9 @@ MonoBehaviour:
   OnSelectedEvent:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 611877319385449779}
-        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
-          Bci4Kids.BciEssentials.Runtime
+      - m_Target: {fileID: 2364165486713040064}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.CanvasColorFlashEffect,
+          Assembly-CSharp
         m_MethodName: Play
         m_Mode: 1
         m_Arguments:
@@ -1800,7 +1800,7 @@ GameObject:
   - component: {fileID: 6063160319026526717}
   - component: {fileID: 2847942383612381812}
   - component: {fileID: 8163365981475531111}
-  - component: {fileID: 3305226368716874745}
+  - component: {fileID: 2409295025597468113}
   - component: {fileID: 7511090427285945928}
   m_Layer: 6
   m_Name: BallColorButton
@@ -1911,7 +1911,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
---- !u!114 &3305226368716874745
+--- !u!114 &2409295025597468113
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1920,7 +1920,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 5754980578906772579}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7720a1dc0ec4493980b36fef8105f94a, type: 3}
+  m_Script: {fileID: 11500000, guid: 535bf50698404674ead34b338e36e3b0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   _renderer: {fileID: 0}
@@ -1944,9 +1944,9 @@ MonoBehaviour:
   StartStimulusEvent:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 3305226368716874745}
-        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
-          Bci4Kids.BciEssentials.Runtime
+      - m_Target: {fileID: 2409295025597468113}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.CanvasColorFlashEffect,
+          Assembly-CSharp
         m_MethodName: SetOn
         m_Mode: 1
         m_Arguments:
@@ -1960,9 +1960,9 @@ MonoBehaviour:
   StopStimulusEvent:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 3305226368716874745}
-        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
-          Bci4Kids.BciEssentials.Runtime
+      - m_Target: {fileID: 2409295025597468113}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.CanvasColorFlashEffect,
+          Assembly-CSharp
         m_MethodName: SetOff
         m_Mode: 1
         m_Arguments:
@@ -1976,9 +1976,9 @@ MonoBehaviour:
   OnSelectedEvent:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 3305226368716874745}
-        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
-          Bci4Kids.BciEssentials.Runtime
+      - m_Target: {fileID: 2409295025597468113}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.CanvasColorFlashEffect,
+          Assembly-CSharp
         m_MethodName: Play
         m_Mode: 1
         m_Arguments:
@@ -2533,7 +2533,7 @@ GameObject:
   - component: {fileID: 8445251991010630657}
   - component: {fileID: 473668909283045256}
   - component: {fileID: 5790848212467436699}
-  - component: {fileID: 5363301401730856394}
+  - component: {fileID: 4005011814417834446}
   - component: {fileID: 4326876296027433403}
   m_Layer: 6
   m_Name: ResetRampButton
@@ -2644,7 +2644,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
---- !u!114 &5363301401730856394
+--- !u!114 &4005011814417834446
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2653,7 +2653,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 7983456653138342303}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7720a1dc0ec4493980b36fef8105f94a, type: 3}
+  m_Script: {fileID: 11500000, guid: 535bf50698404674ead34b338e36e3b0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   _renderer: {fileID: 0}
@@ -2677,9 +2677,9 @@ MonoBehaviour:
   StartStimulusEvent:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 5363301401730856394}
-        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
-          Bci4Kids.BciEssentials.Runtime
+      - m_Target: {fileID: 4005011814417834446}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.CanvasColorFlashEffect,
+          Assembly-CSharp
         m_MethodName: SetOn
         m_Mode: 1
         m_Arguments:
@@ -2693,9 +2693,9 @@ MonoBehaviour:
   StopStimulusEvent:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 5363301401730856394}
-        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
-          Bci4Kids.BciEssentials.Runtime
+      - m_Target: {fileID: 4005011814417834446}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.CanvasColorFlashEffect,
+          Assembly-CSharp
         m_MethodName: SetOff
         m_Mode: 1
         m_Arguments:
@@ -2709,9 +2709,9 @@ MonoBehaviour:
   OnSelectedEvent:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 5363301401730856394}
-        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
-          Bci4Kids.BciEssentials.Runtime
+      - m_Target: {fileID: 4005011814417834446}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.CanvasColorFlashEffect,
+          Assembly-CSharp
         m_MethodName: Play
         m_Mode: 1
         m_Arguments:
@@ -2877,7 +2877,7 @@ GameObject:
   - component: {fileID: 1194208003963516333}
   - component: {fileID: 2229748811494752026}
   - component: {fileID: 8216782688655078050}
-  - component: {fileID: 8028214199397407012}
+  - component: {fileID: 3235224418995685258}
   - component: {fileID: 5831516321743215832}
   m_Layer: 6
   m_Name: ResetBallsButton
@@ -2988,7 +2988,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
---- !u!114 &8028214199397407012
+--- !u!114 &3235224418995685258
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2997,7 +2997,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8476152213448098857}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7720a1dc0ec4493980b36fef8105f94a, type: 3}
+  m_Script: {fileID: 11500000, guid: 535bf50698404674ead34b338e36e3b0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   _renderer: {fileID: 0}
@@ -3021,9 +3021,9 @@ MonoBehaviour:
   StartStimulusEvent:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 8028214199397407012}
-        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
-          Bci4Kids.BciEssentials.Runtime
+      - m_Target: {fileID: 3235224418995685258}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.CanvasColorFlashEffect,
+          Assembly-CSharp
         m_MethodName: SetOn
         m_Mode: 1
         m_Arguments:
@@ -3037,9 +3037,9 @@ MonoBehaviour:
   StopStimulusEvent:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 8028214199397407012}
-        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
-          Bci4Kids.BciEssentials.Runtime
+      - m_Target: {fileID: 3235224418995685258}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.CanvasColorFlashEffect,
+          Assembly-CSharp
         m_MethodName: SetOff
         m_Mode: 1
         m_Arguments:
@@ -3053,9 +3053,9 @@ MonoBehaviour:
   OnSelectedEvent:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 8028214199397407012}
-        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
-          Bci4Kids.BciEssentials.Runtime
+      - m_Target: {fileID: 3235224418995685258}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.CanvasColorFlashEffect,
+          Assembly-CSharp
         m_MethodName: Play
         m_Mode: 1
         m_Arguments:

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
@@ -1266,9 +1266,11 @@ GameObject:
   - component: {fileID: 3931406161124561486}
   - component: {fileID: 5591672340010151945}
   - component: {fileID: 5307156225035156463}
+  - component: {fileID: 611877319385449779}
+  - component: {fileID: 3249766819828270722}
   m_Layer: 6
   m_Name: RandomJackButton
-  m_TagString: Untagged
+  m_TagString: BCI
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1375,6 +1377,93 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &611877319385449779
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4303601759080381808}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7720a1dc0ec4493980b36fef8105f94a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _renderer: {fileID: 0}
+  _flashOnColor: {r: 1, g: 0, b: 0, a: 1}
+  _flashOffColor: {r: 1, g: 1, b: 1, a: 1}
+  _startOn: 0
+  _flashDurationSeconds: 0.2
+  _flashAmount: 3
+--- !u!114 &3249766819828270722
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4303601759080381808}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58dafbcfd2f661d438f57f8ab612995a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  StartStimulusEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 611877319385449779}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials.Runtime
+        m_MethodName: SetOn
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  StopStimulusEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 611877319385449779}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials.Runtime
+        m_MethodName: SetOff
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  OnSelectedEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 611877319385449779}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials.Runtime
+        m_MethodName: Play
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  StartTrainingStimulusEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  StopTrainingStimulusEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  Selectable: 1
+  SelectablePoolIndex: 0
+  ObjectID: 39
 --- !u!1 &4539551266856479437
 GameObject:
   m_ObjectHideFlags: 0
@@ -1711,9 +1800,11 @@ GameObject:
   - component: {fileID: 6063160319026526717}
   - component: {fileID: 2847942383612381812}
   - component: {fileID: 8163365981475531111}
+  - component: {fileID: 3305226368716874745}
+  - component: {fileID: 7511090427285945928}
   m_Layer: 6
   m_Name: BallColorButton
-  m_TagString: Untagged
+  m_TagString: BCI
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1820,6 +1911,93 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &3305226368716874745
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5754980578906772579}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7720a1dc0ec4493980b36fef8105f94a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _renderer: {fileID: 0}
+  _flashOnColor: {r: 1, g: 0, b: 0, a: 1}
+  _flashOffColor: {r: 1, g: 1, b: 1, a: 1}
+  _startOn: 0
+  _flashDurationSeconds: 0.2
+  _flashAmount: 3
+--- !u!114 &7511090427285945928
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5754980578906772579}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58dafbcfd2f661d438f57f8ab612995a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  StartStimulusEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3305226368716874745}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials.Runtime
+        m_MethodName: SetOn
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  StopStimulusEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3305226368716874745}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials.Runtime
+        m_MethodName: SetOff
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  OnSelectedEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3305226368716874745}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials.Runtime
+        m_MethodName: Play
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  StartTrainingStimulusEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  StopTrainingStimulusEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  Selectable: 1
+  SelectablePoolIndex: 0
+  ObjectID: 0
 --- !u!1 &5838688182821822396
 GameObject:
   m_ObjectHideFlags: 0
@@ -2355,9 +2533,11 @@ GameObject:
   - component: {fileID: 8445251991010630657}
   - component: {fileID: 473668909283045256}
   - component: {fileID: 5790848212467436699}
+  - component: {fileID: 5363301401730856394}
+  - component: {fileID: 4326876296027433403}
   m_Layer: 6
   m_Name: ResetRampButton
-  m_TagString: Untagged
+  m_TagString: BCI
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -2464,6 +2644,93 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &5363301401730856394
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7983456653138342303}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7720a1dc0ec4493980b36fef8105f94a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _renderer: {fileID: 0}
+  _flashOnColor: {r: 1, g: 0, b: 0, a: 1}
+  _flashOffColor: {r: 1, g: 1, b: 1, a: 1}
+  _startOn: 0
+  _flashDurationSeconds: 0.2
+  _flashAmount: 3
+--- !u!114 &4326876296027433403
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7983456653138342303}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58dafbcfd2f661d438f57f8ab612995a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  StartStimulusEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5363301401730856394}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials.Runtime
+        m_MethodName: SetOn
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  StopStimulusEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5363301401730856394}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials.Runtime
+        m_MethodName: SetOff
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  OnSelectedEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5363301401730856394}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials.Runtime
+        m_MethodName: Play
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  StartTrainingStimulusEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  StopTrainingStimulusEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  Selectable: 1
+  SelectablePoolIndex: 0
+  ObjectID: 37
 --- !u!1 &8029773889997611271
 GameObject:
   m_ObjectHideFlags: 0
@@ -2610,9 +2877,11 @@ GameObject:
   - component: {fileID: 1194208003963516333}
   - component: {fileID: 2229748811494752026}
   - component: {fileID: 8216782688655078050}
+  - component: {fileID: 8028214199397407012}
+  - component: {fileID: 5831516321743215832}
   m_Layer: 6
   m_Name: ResetBallsButton
-  m_TagString: Untagged
+  m_TagString: BCI
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -2719,3 +2988,90 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &8028214199397407012
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8476152213448098857}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7720a1dc0ec4493980b36fef8105f94a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _renderer: {fileID: 0}
+  _flashOnColor: {r: 1, g: 0, b: 0, a: 1}
+  _flashOffColor: {r: 1, g: 1, b: 1, a: 1}
+  _startOn: 0
+  _flashDurationSeconds: 0.2
+  _flashAmount: 3
+--- !u!114 &5831516321743215832
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8476152213448098857}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58dafbcfd2f661d438f57f8ab612995a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  StartStimulusEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 8028214199397407012}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials.Runtime
+        m_MethodName: SetOn
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  StopStimulusEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 8028214199397407012}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials.Runtime
+        m_MethodName: SetOff
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  OnSelectedEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 8028214199397407012}
+        m_TargetAssemblyTypeName: BCIEssentials.StimulusEffects.ColorFlashEffect,
+          Bci4Kids.BciEssentials.Runtime
+        m_MethodName: Play
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  StartTrainingStimulusEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  StopTrainingStimulusEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  Selectable: 1
+  SelectablePoolIndex: 0
+  ObjectID: 38

--- a/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
+++ b/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
@@ -345,6 +345,10 @@ PrefabInstance:
     m_TransformParent: {fileID: 2146497314}
     m_Modifications:
     - target: {fileID: 259470118614894169, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 259470118614894169, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
@@ -397,7 +401,15 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2695175203650030251, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2695175203650030251, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
       propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2695175203650030251, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
+      propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2924849139167696035, guid: 790711e5c732c6143ae08c994d77dca2, type: 3}
@@ -1880,6 +1892,10 @@ PrefabInstance:
       propertyPath: m_Layer
       value: 6
       objectReference: {fileID: 0}
+    - target: {fileID: 3249766819828270722, guid: 6a619933318bf764aa5fb150788918f3, type: 3}
+      propertyPath: ObjectID
+      value: 40
+      objectReference: {fileID: 0}
     - target: {fileID: 3576948454555312335, guid: 6a619933318bf764aa5fb150788918f3, type: 3}
       propertyPath: randomJackButton
       value: 
@@ -1903,6 +1919,10 @@ PrefabInstance:
     - target: {fileID: 4818931384772691849, guid: 6a619933318bf764aa5fb150788918f3, type: 3}
       propertyPath: m_Layer
       value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7511090427285945928, guid: 6a619933318bf764aa5fb150788918f3, type: 3}
+      propertyPath: ObjectID
+      value: 39
       objectReference: {fileID: 0}
     - target: {fileID: 7764173004061172451, guid: 6a619933318bf764aa5fb150788918f3, type: 3}
       propertyPath: m_LocalPosition.x


### PR DESCRIPTION
Implementation
Connected the `SPO.OnSelectedEvent` listener to the segment clicks and the SPO buttons in play and virtual play

Testing
- Start the game and in game options change the fine fan to a 2 x 2 grid
- Go to virtual play and select a fan segment to switch from the coarse fan to the fine fan
- Without stopping the game, use the search function in the hierarchy and search for "SPO"
- Using the scene view, select the button of interest from the hierarchy. You need the scene view to mark in green which button you'll be pressing in the game.
- While the button of interest is selected, scroll down on the inspector and look for the `SPO/Selectable pool index` option.
- Go back to the game and press "S" to start the stimulus
- The `SPO/Selectable pool index` will change, press the new number in your keyboard
- Once the flashing animation is done, the button of interest should be pressed and the corresponding action should ocurr