### PR TITLE
66-coarse-fan-resets

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanNamespace.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanNamespace.cs
@@ -21,32 +21,52 @@ namespace FanNamespace
     [CreateAssetMenu(fileName = "FanSettings", menuName = "Fan/FanSettings")]
     public class FanSettings : ScriptableObject
     {
+        // Ranges for the fan settings
+        BocciaModel _model; // Reference to the model
+        private readonly int _minColumns = 1;
+        private readonly int _maxColumns = 7;
+        
+        private readonly int _minRows = 1;
+        private readonly int _maxRows = 7;
+        
+        private readonly int _minCoarseTheta = 5 ;
+        private readonly int _maxCoarseTheta = 170;
+
+        private readonly int _minFineTheta = 5;
+        private readonly int _maxFineTheta = 50;
+        
+        private readonly int _minElevationRange = 1;
+        private readonly int _maxElevationRange = 100;        
+
+        private readonly int _minRadiusDifference = 1;   // Minimum difference between inner and outer radius
+
+        // Public getters to send to model
+        public int MinColumns { get { return _minColumns; } }
+        public int MaxColumns { get { return _maxColumns; } }
+
+        public int MinRows { get { return _minRows; } }
+        public int MaxRows { get { return _maxRows; } }
+
+        public int MinCoarseTheta { get { return _minCoarseTheta; } }
+        public int MaxCoarseTheta { get { return _maxCoarseTheta; } }
+
+        public int MinFineTheta { get { return _minFineTheta; } }
+        public int MaxFineTheta { get { return _maxFineTheta; } }
+
+        public int MinElevationRange { get { return _minElevationRange; } }
+        public int MaxElevationRange { get { return _maxElevationRange; } }
+
         [Header("Fan Parameters")]
         public float columnSpacing; // Spacing between columns
         public float rowSpacing;    // Spacing between rows;
-
-        private int _minColumns;
-        private int _maxColumns;
-        public int MaxColumns { get { return _maxColumns; } }
-
-        private int _minRows;
-        private int _maxRows;
-        public int MaxRows { get { return _maxRows; } }
-
-        private int _minTheta;
-        private int _maxTheta;
-
-        private int _minElevationRange;
-        private int _maxElevationRange;
-
-        private int _minRadiusDifference = 1;   // Minimum difference between inner and outer radius
-
+       
+        // Conditional sets to stay within ranges
         [SerializeField]
         private float _theta;               // Angle in degrees
         public float Theta
         {
             get { return _theta; }
-            set { _theta = Mathf.Clamp(value, _minTheta, _maxTheta); }
+            set { _theta = Mathf.Clamp(value, _minCoarseTheta, _maxCoarseTheta); }
         }
 
         [SerializeField]
@@ -112,22 +132,6 @@ namespace FanNamespace
 
         [Header("Annotation options")]
         public int annotationFontSize;
-
-        public void Setup(BocciaModel model)
-        {
-            // Initialize min and max columns and rows based on centralized model settings
-            _minColumns = model.FanSettings.RotationPrecisionMin;
-            _maxColumns = model.FanSettings.RotationPrecisionMax;
-
-            _minRows = model.FanSettings.ElevationPrecisionMin;
-            _maxRows = model.FanSettings.ElevationPrecisionMax;
-
-            _minTheta = model.FanSettings.RotationRangeMin;
-            _maxTheta = model.FanSettings.RotationRangeMax;
-
-            _minElevationRange = model.FanSettings.ElevationRangeMin;
-            _maxElevationRange = model.FanSettings.ElevationRangeMax;
-        }
 
         private void OnValidate()
         {

--- a/Boccia-Unity/Assets/Boccia/BCI/FanNamespace.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanNamespace.cs
@@ -89,8 +89,7 @@ namespace FanNamespace
         private float _elevationRange; // Elevation range [%]
         public float ElevationRange
         {
-            get { return _elevationRange; } //There is some bug where the value is not being clamped. Going to do this on return now.
-            // set { _elevationRange = Mathf.Clamp(value, 1, 100); }
+            get { return _elevationRange; } 
             set { _elevationRange = Mathf.Clamp(value, _minElevationRange, _maxElevationRange); }
         }
 

--- a/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
@@ -42,24 +42,7 @@ public class FanPresenter : MonoBehaviour
 
         _originalRotation = transform.rotation;
 
-        // Initialize the fan settings based on centralized model data
-        InitializeFanSettings();
-
         UpdateFineFan(); // Update fine fan
-    }
-
-    private void InitializeFanSettings()
-    {
-        // Set up _fineFan and _coarseFan using the centralized BocciaModel
-        if (_fineFan != null)
-        {
-            _fineFan.Setup(_model);
-        }
-
-        if (_coarseFan != null)
-        {
-            _coarseFan.Setup(_model);
-        }
     }
 
     /// <summary>

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -116,6 +116,8 @@ public class BocciaModel : Singleton<BocciaModel>
         // Set Fan settings
         FanSettings fanSettings = Resources.Load<FanSettings>("FanSettings") ?? ScriptableObject.CreateInstance<FanSettings>();
         SetFanSettings(fanSettings);
+        ScriptableObject.Destroy(fanSettings);
+        
 
         // Set Ramp Settings
         SetRampSettings();

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using FanNamespace;
 using Unity.VisualScripting;
 using UnityEditor.UI;
 using UnityEngine;
@@ -113,7 +114,8 @@ public class BocciaModel : Singleton<BocciaModel>
         SetDefaultHardwareOptions();
 
         // Set Fan settings
-        SetFanSettings();
+        FanSettings fanSettings = Resources.Load<FanSettings>("FanSettings") ?? ScriptableObject.CreateInstance<FanSettings>();
+        SetFanSettings(fanSettings);
 
         // Set Ramp Settings
         SetRampSettings();
@@ -181,25 +183,20 @@ public class BocciaModel : Singleton<BocciaModel>
         bocciaData.RampSettings.RotationSpeedMax = 1000;
     }
 
-    // Set FanSettings
-    private void SetFanSettings()
+    /// <summary>
+    /// Grabs the FanSettings from the FanNamespace and sets them in the model.
+    /// </summary>
+    /// <param name="fanSettings">The FanSettings object containing the settings to be applied.</param>
+    public void SetFanSettings(FanSettings fanSettings)
     {
-        // ElevationRange
-        bocciaData.FanSettings.ElevationRangeMin = 1;
-        bocciaData.FanSettings.ElevationRangeMax = 100;
-
-        // ElevationPrecision
-        bocciaData.FanSettings.ElevationPrecisionMin = 1;
-        bocciaData.FanSettings.ElevationPrecisionMax = 7;
-
-        // RotationRange
-        // Also sets limits on Theta for Fan generation
-        bocciaData.FanSettings.RotationRangeMin = 5;
-        bocciaData.FanSettings.RotationRangeMax = 180;
-
-        // RotationPrecision
-        bocciaData.FanSettings.RotationPrecisionMin = 1;
-        bocciaData.FanSettings.RotationPrecisionMax = 7;
+        bocciaData.FanSettings.RotationPrecisionMin = fanSettings.MinColumns;
+        bocciaData.FanSettings.RotationPrecisionMax = fanSettings.MaxColumns;
+        bocciaData.FanSettings.ElevationPrecisionMin = fanSettings.MinRows;
+        bocciaData.FanSettings.ElevationPrecisionMax = fanSettings.MaxRows;
+        bocciaData.FanSettings.RotationRangeMin = fanSettings.MinFineTheta;
+        bocciaData.FanSettings.RotationRangeMax = fanSettings.MaxFineTheta;
+        bocciaData.FanSettings.ElevationRangeMin = fanSettings.MinElevationRange;
+        bocciaData.FanSettings.ElevationRangeMax = fanSettings.MaxElevationRange;
     }
 
     // MARK: Game options


### PR DESCRIPTION
# Description
Fixed the bud where the coarseFan values are reset due to the model not being initialized before the ScriptableObject.

My approach to this was to create a fanSettings instance in the model initialization to pull the default values from. Once the defaults are in the model, they can be used for the GameOptions UI.

I am not very sure on how to replicate the issue of the CoarseFan dissapearing, but it seems that it doesn't happen any more. 

# Testing 
- Open the `FanNamespace.cs` script and change one of the default properties in the `FanSettings`.
- Go in the inspector and locate the gameObject you will change the setting to
- Start play mode
- See the new default loading
- If the setting can be modified in the GameOptions menu, the expected limit should be set in place.

# Note
You need to get Unity to recompile the scripts, otherwise the values set in `FanSettings` will not update on run