### PR TITLE
Improve fan annotations

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
@@ -13,6 +13,8 @@ public class FanGenerator : MonoBehaviour
     public Material material;
     public Color colour = Color.grey;
 
+    public GameObject fanAnnotations;
+
     public void GenerateFanShape(FanSettings fanSettings)
     {        
         float angleStep = fanSettings.Theta / fanSettings.NColumns;
@@ -220,9 +222,9 @@ public class FanGenerator : MonoBehaviour
     
     private void CreateTextAnnotation(Vector3 position, float rotationAngle, string text, TextAlignmentOptions textAlignment, float annotationFontSize)
     {
-        GameObject textObject = new ("TextAnnotation");
-        textObject.transform.SetParent(transform);
-        textObject.layer = LayerMask.NameToLayer("VirtualPlayUI");
+        GameObject textObject = Instantiate(fanAnnotations, transform);
+        textObject.name = "TextAnnotation";
+
         textObject.transform.SetLocalPositionAndRotation
         (
             position,
@@ -230,7 +232,7 @@ public class FanGenerator : MonoBehaviour
         );
 
         // Add and configure RectTransform
-        RectTransform rectTransform = textObject.AddComponent<RectTransform>();
+        RectTransform rectTransform = textObject.GetComponent<RectTransform>();
         switch (textAlignment)
         {
             case TextAlignmentOptions.BottomLeft:
@@ -258,15 +260,12 @@ public class FanGenerator : MonoBehaviour
                 break;
         }
         
-        // rectTransform.anchoredPosition = Vector2.zero;
-        rectTransform.sizeDelta = new Vector2(5, 2);
-
-        // Add and configure TextMeshPro
-        TextMeshPro textMeshPro = textObject.AddComponent<TextMeshPro>();
-        textMeshPro.text = text;
-        textMeshPro.fontSize = annotationFontSize;
-        textMeshPro.color = Color.black;
-        textMeshPro.alignment = textAlignment;
-        textMeshPro.font = Resources.Load<TMP_FontAsset>("Assets/TextMesh Pro/Fonts/LiberationSans.ttf"); // Replace with your font asset path
+        TextMeshPro textMeshProComponent = textObject.GetComponent<TextMeshPro>();
+        if (textMeshProComponent != null)
+        {
+            textMeshProComponent.text = text;
+            textMeshProComponent.fontSize = annotationFontSize;
+            textMeshProComponent.alignment = textAlignment;
+        }
     }
 }

--- a/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
@@ -146,8 +146,11 @@ public class FanGenerator : MonoBehaviour
         return mesh;
     }
 
-    public void GenerateFanAnnotations(FanSettings fanSettings, float currentRotation, float currentElevation, BackButtonPositioningMode backButtonPositioningMode)
+    public void GenerateFanAnnotations(FanSettings fanSettings, float currentRotation, float currentElevation, BackButtonPositioningMode backButtonPositioningMode, FanPositioningMode fanPositioningMode)
     {   
+        // Get scaled font size for Fine Fan based on Fine Fan theta
+        float scaledFontSize = ScaleAnnotationSize(fanSettings, fanPositioningMode);
+
         // Annotation for the start angle
         float startAngle = 0;
         float startRad = Mathf.Deg2Rad * startAngle;
@@ -159,7 +162,7 @@ public class FanGenerator : MonoBehaviour
             rotationAngle: 0,
             (currentRotation + fanSettings.Theta/2).ToString("F1") + "°",
             TextAlignmentOptions.BottomRight,
-            annotationFontSize: fanSettings.annotationFontSize
+            annotationFontSize: scaledFontSize
         );
 
         // Annotation for the end angle
@@ -172,7 +175,7 @@ public class FanGenerator : MonoBehaviour
             rotationAngle: fanSettings.Theta,
             (currentRotation - fanSettings.Theta/2).ToString("F1") + "°",
             TextAlignmentOptions.BottomLeft,
-            annotationFontSize: fanSettings.annotationFontSize
+            annotationFontSize: scaledFontSize
         );
 
         // Place height anotations according to back button position 
@@ -268,4 +271,41 @@ public class FanGenerator : MonoBehaviour
             textMeshProComponent.alignment = textAlignment;
         }
     }
-}
+
+
+    // This scales the font size so we can see the annotations (for now)
+    private float ScaleAnnotationSize(FanSettings fanSettings, FanPositioningMode fanPositioningMode)
+    {
+        if (fanPositioningMode == FanPositioningMode.CenterToBase)
+        {
+            return fanSettings.annotationFontSize;
+        }
+
+        float baseFontSize = fanSettings.annotationFontSize;
+        float theta = fanSettings.Theta;
+
+        if (theta > 21)
+        {
+            return baseFontSize;
+        }
+
+        if (15 < theta && theta <= 21)
+        {
+            float scaledFontSize = baseFontSize * 0.8f;
+            return scaledFontSize;
+        }
+
+        else if (12 < theta && theta <= 15)
+        {
+            float scaledFontSize = baseFontSize * 0.6f;
+            return scaledFontSize;
+        }
+
+        else 
+        {
+            float scaledFontSize = baseFontSize * 0.5f;
+            Debug.Log($"Scaled font size: {scaledFontSize}");
+            return scaledFontSize;
+        }
+    }
+}   

--- a/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
@@ -170,7 +170,7 @@ public class FanPresenter : MonoBehaviour
                 fanGenerator.GenerateBackButton(_fineFan, backButtonPositioningMode);
                 fanGenerator.GenerateDropButton(_fineFan);
                 fanInteractions.MakeFanSegmentsInteractable(_fineFan);
-                fanGenerator.GenerateFanAnnotations(_fineFan, _model.RampRotation, _model.RampElevation, backButtonPositioningMode);
+                fanGenerator.GenerateFanAnnotations(_fineFan, _model.RampRotation, _model.RampElevation, backButtonPositioningMode, positioningMode);
                 break;
             case FanPositioningMode.CenterToBase:
                 CenterNorth();
@@ -178,7 +178,7 @@ public class FanPresenter : MonoBehaviour
                 fanGenerator.GenerateBackButton(_coarseFan, BackButtonPositioningMode.None);
                 fanGenerator.GenerateDropButton(_coarseFan);
                 fanInteractions.MakeFanSegmentsInteractable(_coarseFan);
-                fanGenerator.GenerateFanAnnotations(_coarseFan, 0, _coarseFan.ElevationRange/2, backButtonPositioningMode);
+                fanGenerator.GenerateFanAnnotations(_coarseFan, 0, _coarseFan.ElevationRange/2, backButtonPositioningMode, positioningMode);
 
                 // Change settings so that next fan is 
                 // positioningMode = FanPositioningMode.CenterToRails;

--- a/Boccia-Unity/Assets/Boccia/BCI/RampControlFan.prefab
+++ b/Boccia-Unity/Assets/Boccia/BCI/RampControlFan.prefab
@@ -67,6 +67,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   material: {fileID: 2100000, guid: fc80352a2baed914fa228646173e5f3f, type: 2}
   colour: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  fanAnnotations: {fileID: 8655961538621574760, guid: cb8177dd45c161c44bd3d192f6de8adc, type: 3}
 --- !u!114 &-7705321522961072228
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/TextAnnotation.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/TextAnnotation.prefab
@@ -108,8 +108,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4278190080
-  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/TextAnnotation.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/TextAnnotation.prefab
@@ -27,8 +27,8 @@ RectTransform:
   m_GameObject: {fileID: 8655961538621574760}
   m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.0000001, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/TextAnnotation.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/TextAnnotation.prefab
@@ -1,0 +1,173 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8655961538621574760
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1558930903922298107}
+  - component: {fileID: 4380500509294132030}
+  - component: {fileID: 2070360879037525048}
+  m_Layer: 6
+  m_Name: TextAnnotation
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1558930903922298107
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8655961538621574760}
+  m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.0000001, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 5, y: 2}
+  m_Pivot: {x: 1, y: 0}
+--- !u!23 &4380500509294132030
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8655961538621574760}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: -7470251019685361148, guid: af5aa117d756b4746a28940d43056963, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &2070360879037525048
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8655961538621574760}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Label
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: af5aa117d756b4746a28940d43056963, type: 2}
+  m_sharedMaterial: {fileID: -7470251019685361148, guid: af5aa117d756b4746a28940d43056963, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 5
+  m_fontSizeBase: 5
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 4
+  m_VerticalAlignment: 1024
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 0
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 4380500509294132030}
+  m_maskType: 0

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/TextAnnotation.prefab.meta
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/TextAnnotation.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cb8177dd45c161c44bd3d192f6de8adc
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The fan annotations could be difficult to read since they were black-on-black with the court lines. The annotation font did not match the font used everywhere else.

Also the rotation annotations sometimes overlapped with each other.

Changes:
- I created a prefab asset for the annotations (called `TextAnnotations`) so the correct font could be loaded and to set the text color as white.
- I added a method to scale the font size based on theta. Note: this avoids overlapping annotations for the default theta size, but there are still readability issues for lower values of theta.

Testing:
- In VirtualPlay, you should see that the annotations of the coarse and fine fan now have the correct font and white text to make them stand out better.
- Set the rotation range slider to the default value in GameOptions menu, and you should see that the rotation annotations don't overlap on the fine fan (and the text size is smaller compared to the other annotations).
