### PR TITLE
Change initialization order to on awake

### DIFF
--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -28,7 +28,6 @@ public class BocciaModel : Singleton<BocciaModel>
     private RampController _rampController;
     private RampController _simulatedRamp;
     private HardwareRamp _hardwareRamp;
-    private bool _isInitialized;
 
     public float RampRotation => _rampController.Rotation;
     public float RampElevation => _rampController.Elevation;
@@ -99,17 +98,6 @@ public class BocciaModel : Singleton<BocciaModel>
     {
         base.Awake();
 
-        if (!_isInitialized)
-        {
-            _simulatedRamp = new SimulatedRamp();
-            _hardwareRamp = new HardwareRamp();
-            _rampController = _simulatedRamp; // Default to simulated
-            _isInitialized = true;
-        }
-    }
-
-    public void Start()
-    {
         if (!bocciaData.WasInitialized)
         {
             Debug.Log("Initializing BocciaData...");
@@ -120,7 +108,19 @@ public class BocciaModel : Singleton<BocciaModel>
 
             bocciaData.WasInitialized = true;
         }
+        
+        
+        SetRampSettings();
+        SetDefaultHardwareOptions();
 
+        _simulatedRamp = new SimulatedRamp();
+        _hardwareRamp = new HardwareRamp();
+        _rampController = _simulatedRamp; // Default to simulated
+
+    }
+
+    public void Start()
+    {
         // Initialize the list of possible ball colors
         InitializeBallColorOptions();
 


### PR DESCRIPTION
This is related to [issue 106](https://github.com/kirtonBCIlab/boccia-bci/issues/106).

## Bug behaviours
- There is a `NullReference` error because of how the Boccia model is initialized, the error shows in `RampPresenter` and `BallPresenter`.
- Additionally, the ramp initializes before the model so the elevation mechanism is driven to 0. Thus, if you navigate fast enough, the fan does not appear in Virtual or Play view, until the ramp stops the elevation animation.

## Fix
- Added an `Awake` method in `BocciaModel` for correct initialization of parameters.

## Test
- Start the game in main and observe the bug behaviours noted above.
- Change to the PR branch and the issues should be gone.