### PR TITLE
Add event to reset ball and jack tails

### DIFF
--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -70,6 +70,8 @@ public class BocciaModel : Singleton<BocciaModel>
     public event System.Action BciChanged;
     public event System.Action NewRandomJack;
     public event System.Action BallResetChanged;
+
+    public event System.Action ResetTails;
     public event System.Action BallFallingChanged;
     public event System.Action ResetFan;
 
@@ -329,6 +331,11 @@ public class BocciaModel : Singleton<BocciaModel>
         SendBallResetEvent();
     }
 
+    public void ResetBallTails()
+    {
+        SendTailResetEvent();
+    }
+
     public void RandomBallColor()
     {
         // Get all the keys (color names) from the BallColorOptionsDict
@@ -539,6 +546,11 @@ public class BocciaModel : Singleton<BocciaModel>
     private void SendBallResetEvent()
     {
         BallResetChanged?.Invoke();
+    }
+
+    private void SendTailResetEvent()
+    {
+        ResetTails?.Invoke();
     }
 
     private void SendBallFallingEvent()

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -221,6 +221,9 @@ public class BallPresenter : MonoBehaviour
         {
             GameObject previousBall = _activeBall;
             Destroy(previousBall);
+            
+            // Call the method to remove the ball tail
+            _model.ResetBallTails();
         }
 
         // Instantiate the new ball
@@ -278,6 +281,9 @@ public class BallPresenter : MonoBehaviour
                 Destroy(child.gameObject);
             }
         }
+
+        // Call the method to remove the ball tails
+        _model.ResetBallTails();
     }
 
     private void NavigationChanged()

--- a/Boccia-Unity/Assets/Boccia/Ramp/JackPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/JackPresenter.cs
@@ -58,6 +58,9 @@ public class JackPresenter : MonoBehaviour
         if (currentJack != null)
         {
             Destroy(currentJack);
+
+            // Call the method to remove tail
+            _model.ResetBallTails();
         }
     }
 

--- a/Boccia-Unity/Assets/Boccia/Ramp/TailPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/TailPresenter.cs
@@ -31,7 +31,7 @@ public class TailPresenter : MonoBehaviour
         GetComponent<BallPresenter>().BallDropped += BallDropped;
         GetComponent<JackPresenter>().JackSpawned += JackSpawned;
         _model.WasChanged += ModelChanged;
-        _model.BallResetChanged += ResetTails;
+        _model.ResetTails += ResetTails;
     }
 
 


### PR DESCRIPTION
This is to fix [issue 95](https://github.com/kirtonBCIlab/boccia-bci/issues/95).

**Issue Description**

There is a `NullReference` error that happens when the ball tails are not destroyed when the balls are removed from the scene.

- In the Play screen, the ball tail is not removed when the ball disappears.
- If you are in VirtualPlay and navigate back to the Play Menu, any balls (including the jack) in the scene will be removed, but the ball tails will remain in the scene.

Both scenarios cause the NullRef error. This breaks the fan and Reset Ramp button (and the Random Ball button in the Play screen).

**Changes**

- Added a ResetTails event in the model to account for all scenarios where the ball tail needs to be removed.


**Testing**

- Go to the Play screen. 
- Drop a ball and observe that its tail is removed with the ball when it stops rolling.
- Verify that the fan, Reset Ramp, and Random Ball buttons did not break.
- Go to the Virtual Play screen. 
- Release a ball and/or the jack.
- Navigate to the Play Menu, and observe that the balls _and_ tails are removed.