### PR TITLE
Fix ramp visualization

### DIFF
--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -193,7 +193,7 @@ public class BocciaModel : Singleton<BocciaModel>
         // (e.g. cm/s or deg/s)
         bocciaData.RampSettings.ElevationSpeedMin = 1;
         bocciaData.RampSettings.ElevationSpeedMax = 255;
-        bocciaData.RampSettings.RotationSpeedMin = 1;
+        bocciaData.RampSettings.RotationSpeedMin = 300;
         bocciaData.RampSettings.RotationSpeedMax = 1000;
     }
 

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -276,6 +276,7 @@ public class BocciaModel : Singleton<BocciaModel>
     public void ElevateTo(float elevation) => rampController.ElevateTo(elevation);
 
     public float ScaleRotationSpeed(float speed) => _hardwareRamp.ScaleRotationSpeed(speed);
+    public float ScaleRotationAcceleration() => _hardwareRamp.ScaleRotationAcceleration();
     public float ScaleElevationSpeed(float speed) => _hardwareRamp.ScaleElevationSpeed(speed);
 
     public void ResetRampPosition() => rampController.ResetRampPosition();

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -151,6 +151,9 @@ public class BocciaModel : Singleton<BocciaModel>
             {"Elevation", false},
             {"Rotation", false}
         };
+
+        // Movement settings
+        
     }
 
     // Set RampSettings

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -147,11 +147,16 @@ public class HardwareRamp : RampController, ISerialController
         return scaledAcceleration;
     }
 
+    /// <summary>
+    /// Scales elevation speed for correct visualization
+    /// </summary>
+    /// <param name="speed">8-bit PWM speed </param>
+    /// <returns>Scaled speed [m/s]</returns>
     public float ScaleElevationSpeed(float speed)
     {
         float elevationMotorMaxSpeed = 2.0f;    // Max speed: 2 inches/sec at 35 lbs
         float speedPercentage = speed / (_model.RampSettings.ElevationSpeedMax - _model.RampSettings.ElevationSpeedMin);
-        float scaledSpeed = speedPercentage * elevationMotorMaxSpeed * _rampScaling;
+        float scaledSpeed = speedPercentage * elevationMotorMaxSpeed * _rampScaling * 0.0254f;
         return scaledSpeed;
     }
 

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -44,7 +44,6 @@ public class HardwareRamp : RampController, ISerialController
     private float _rampScaling = 3;                 // Scaling factor: 3 from the Boccia ramp model in the scene
     private float _stepsPerRevolution = 800f;       // Steps per revolution [steps/rev]
     private float _defaultAcceleration = 30f;       // Default acceleration [steps/sec^2]
-    private float _RotationMotorMaxSpeed = 1000f;   // Max speed: [steps/sec] according to AccelStepper library
     private float _gearRatio = 3f;                  // Gear ratio: 3:1
 
     private SerialPort _serial;
@@ -154,9 +153,10 @@ public class HardwareRamp : RampController, ISerialController
     /// <returns>Scaled speed [m/s]</returns>
     public float ScaleElevationSpeed(float speed)
     {
-        float elevationMotorMaxSpeed = 2.0f;    // Max speed: 2 inches/sec at 35 lbs
+        float elevationMotorMaxImperialSpeed = 2.0f;    // Max speed: 2 inches/sec at 35 lbs
+        float elevationMotorMaxMetricSpeed = elevationMotorMaxImperialSpeed * 0.0254f; // Convert to meters
         float speedPercentage = speed / (_model.RampSettings.ElevationSpeedMax - _model.RampSettings.ElevationSpeedMin);
-        float scaledSpeed = speedPercentage * elevationMotorMaxSpeed * _rampScaling * 0.0254f;
+        float scaledSpeed = speedPercentage * elevationMotorMaxMetricSpeed * _rampScaling;
         return scaledSpeed;
     }
 

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -46,6 +46,9 @@ public class HardwareRamp : RampController, ISerialController
     private float _defaultAcceleration = 30f;       // Default acceleration [steps/sec^2]
     private float _gearRatio = 3f;                  // Gear ratio: 3:1
 
+    const float MAX_IMPERIAL_SPEED = 2.0f;  // Max speed: 2 inches/sec at 35 lbs
+    const float INCHES_TO_METERS = 0.0254f; 
+
     private SerialPort _serial;
     private List<string> _serialCommandsList;
     private string _serialCommand;
@@ -127,7 +130,6 @@ public class HardwareRamp : RampController, ISerialController
     /// <returns>Rotation speed [deg/sec]</returns>
     public float ScaleRotationSpeed(float speed)
     {
-        // float speedPercentage = speed / _model.RampSettings.RotationSpeedMax;
         float degreesPerStep = 360f / (_stepsPerRevolution * _gearRatio);
         float scaledSpeed = speed * degreesPerStep;
         return scaledSpeed;
@@ -151,8 +153,6 @@ public class HardwareRamp : RampController, ISerialController
     /// <returns>Scaled speed [m/s]</returns>
     public float ScaleElevationSpeed(float speed)
     {
-        const float MAX_IMPERIAL_SPEED = 2.0f;  // Max speed: 2 inches/sec at 35 lbs
-        const float INCHES_TO_METERS = 0.0254f; 
         float maxMetricSpeed = MAX_IMPERIAL_SPEED * INCHES_TO_METERS;    // Convert to [m/sec]
         
         float speedPercentage = speed / (float)_model.RampSettings.ElevationSpeedMax;

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -130,7 +130,8 @@ public class HardwareRamp : RampController, ISerialController
     {
         // float speedPercentage = speed / _model.RampSettings.RotationSpeedMax;
         float degreesPerStep = 360f / (_stepsPerRevolution * _gearRatio);
-        float scaledSpeed = speed * degreesPerStep / _rampScaling;
+        float scaledSpeed = speed * degreesPerStep;
+        // float scaledSpeed = speed * degreesPerStep / _rampScaling; // IDK IF WE NEED SCALING!
         return scaledSpeed;
     }
 
@@ -141,7 +142,8 @@ public class HardwareRamp : RampController, ISerialController
     public float ScaleRotationAcceleration()
     {
         float degreesPerStep = 360f / (_stepsPerRevolution * _gearRatio);
-        float scaledAcceleration = _defaultAcceleration * degreesPerStep / _rampScaling;
+        float scaledAcceleration = _defaultAcceleration * degreesPerStep;
+        // float scaledAcceleration = _defaultAcceleration * degreesPerStep / _rampScaling;  // IDK IF WE NEED SCALING!
         return scaledAcceleration;
     }
 

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -130,7 +130,6 @@ public class HardwareRamp : RampController, ISerialController
         // float speedPercentage = speed / _model.RampSettings.RotationSpeedMax;
         float degreesPerStep = 360f / (_stepsPerRevolution * _gearRatio);
         float scaledSpeed = speed * degreesPerStep;
-        // float scaledSpeed = speed * degreesPerStep / _rampScaling; // IDK IF WE NEED SCALING!
         return scaledSpeed;
     }
 
@@ -142,7 +141,6 @@ public class HardwareRamp : RampController, ISerialController
     {
         float degreesPerStep = 360f / (_stepsPerRevolution * _gearRatio);
         float scaledAcceleration = _defaultAcceleration * degreesPerStep;
-        // float scaledAcceleration = _defaultAcceleration * degreesPerStep / _rampScaling;  // IDK IF WE NEED SCALING!
         return scaledAcceleration;
     }
 
@@ -153,10 +151,13 @@ public class HardwareRamp : RampController, ISerialController
     /// <returns>Scaled speed [m/s]</returns>
     public float ScaleElevationSpeed(float speed)
     {
-        float elevationMotorMaxImperialSpeed = 2.0f;    // Max speed: 2 inches/sec at 35 lbs
-        float elevationMotorMaxMetricSpeed = elevationMotorMaxImperialSpeed * 0.0254f; // Convert to meters
-        float speedPercentage = speed / (_model.RampSettings.ElevationSpeedMax - _model.RampSettings.ElevationSpeedMin);
-        float scaledSpeed = speedPercentage * elevationMotorMaxMetricSpeed * _rampScaling;
+        const float MAX_IMPERIAL_SPEED = 2.0f;  // Max speed: 2 inches/sec at 35 lbs
+        const float INCHES_TO_METERS = 0.0254f; 
+        float maxMetricSpeed = MAX_IMPERIAL_SPEED * INCHES_TO_METERS;    // Convert to [m/sec]
+        
+        float speedPercentage = speed / (float)_model.RampSettings.ElevationSpeedMax;
+        float scaledSpeed = speedPercentage * maxMetricSpeed;
+        // float scaledSpeed = speedPercentage * maxMetricSpeed * _rampScaling; // Not sure if we need scaling here
         return scaledSpeed;
     }
 

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -41,7 +41,7 @@ public class HardwareRamp : RampController, ISerialController
     public bool SerialEnabled { get; private set; }    
 
     // Values from Hardware ramp firmware controller
-    private float _rampScaling = 3;                 // Scaling factor: 3 from the Boccia ramp model in the scene
+    //private float _rampScaling = 3;                 // Scaling factor: 3 from the Boccia ramp model in the scene
     private float _stepsPerRevolution = 800f;       // Steps per revolution [steps/rev]
     private float _defaultAcceleration = 30f;       // Default acceleration [steps/sec^2]
     private float _gearRatio = 3f;                  // Gear ratio: 3:1

--- a/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
@@ -97,23 +97,50 @@ public class RampPresenter : MonoBehaviour
 
         // Get the scaled rotation speed and convert it to degrees per second
         float scaledSpeed = _model.ScaleRotationSpeed(_rotationSpeed);
-        float convertedSpeed = scaledSpeed * 360f;
+
+        // Define the acceleration in steps/sec² and scale it
+        float scaledAcceleration = _model.ScaleRotationAcceleration();
+        Debug.Log("Scaled acceleration: " + scaledAcceleration);
 
         // Calculate the total time it will take to rotate
-        float totalTime = rotationAngle / convertedSpeed;
+        float totalTime = rotationAngle / scaledSpeed;
+        Debug.Log("Rotation angle: " + rotationAngle);
+        Debug.Log("Scaled speed: " + scaledSpeed);
+        Debug.Log("Total time to rotate: " + totalTime);
         // Variable to store the current time
         float elapsedTime = 0f;
+
+        float currentSpeed = 0f;
+        float currentAngle = 0f;
 
         // Rotate the ramp
         while (elapsedTime < totalTime)
         {
             elapsedTime += Time.deltaTime;
+            float t = elapsedTime / totalTime;
+            // float easeInOutFactor = t * t * (3f - 2f * t); // Smoothstep function
+            // Calculate the current speed with acceleration and deceleration
+            if (t < 0.5f)
+            {
+                // Accelerate
+                currentSpeed += scaledAcceleration * Time.deltaTime;
+            }
+            else
+            {
+                // Decelerate
+                currentSpeed -= scaledAcceleration * Time.deltaTime;
+            }
+            currentSpeed = Mathf.Max(currentSpeed, 0f);
 
-            // Interpolation factor to smooth out the rotation
-            float normalizedProgress = Mathf.SmoothStep(0f, 1f, (Mathf.Clamp01(elapsedTime / totalTime)));
+            // Calculate the current speed with acceleration
+            // float currentSpeed = scaledSpeed * easeInOutFactor;
+            // float currentAngle = currentSpeed * elapsedTime + 0.5f * scaledAcceleration * Mathf.Pow(elapsedTime, 2);
+            currentAngle += currentSpeed * Time.deltaTime;
 
             // Interpolate between the start and target rotation
-            rotationShaft.transform.localRotation = Quaternion.Lerp(startRotation, targetRotation, normalizedProgress);
+            Debug.Log("Current angle: " + currentAngle);
+            float normalizedAngle = Mathf.Clamp01(currentAngle / rotationAngle);
+            rotationShaft.transform.localRotation = Quaternion.Lerp(startRotation, targetRotation, normalizedAngle);
 
             yield return null;
         }

--- a/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
@@ -87,21 +87,39 @@ public class RampPresenter : MonoBehaviour
 
     private IEnumerator RotationVisualization()
     {
-        // Smoothly show the rotation of the ramp to the new position
-        Quaternion currentRotation = rotationShaft.transform.localRotation;
-        // Debug.Log("Current Rotation: " + currentRotation.eulerAngles);
-        Quaternion targetQuaternion = Quaternion.Euler(rotationShaft.transform.localEulerAngles.x, _model.RampRotation, rotationShaft.transform.localEulerAngles.z);
-        // Debug.Log($"model.RampRotation value: {_model.RampRotation}");
+        // Store the starting rotation
+        Quaternion startRotation = rotationShaft.transform.localRotation;
+        // Store the target rotation based on the model.RampRotation value
+        Quaternion targetRotation = Quaternion.Euler(rotationShaft.transform.localEulerAngles.x, _model.RampRotation, rotationShaft.transform.localEulerAngles.z);
 
-        while (Quaternion.Angle(currentRotation, targetQuaternion) > 0.01f)
+        // Calculate the angle between the start and target rotations
+        float rotationAngle = Quaternion.Angle(startRotation, targetRotation);
+
+        // Get the scaled rotation speed and convert it to degrees per second
+        float scaledSpeed = _model.ScaleRotationSpeed(_rotationSpeed);
+        float convertedSpeed = scaledSpeed * 360f;
+
+        // Calculate the total time it will take to rotate
+        float totalTime = rotationAngle / convertedSpeed;
+        // Variable to store the current time
+        float elapsedTime = 0f;
+
+        // Rotate the ramp
+        while (elapsedTime < totalTime)
         {
-            float scaledSpeed = _model.ScaleRotationSpeed(_rotationSpeed);
-            currentRotation = Quaternion.Lerp(currentRotation, targetQuaternion, scaledSpeed * Time.deltaTime);
-            rotationShaft.transform.localRotation = currentRotation;
+            elapsedTime += Time.deltaTime;
+
+            // Interpolation factor
+            float normalizedProgress = Mathf.Clamp01(elapsedTime / totalTime);
+
+            // Interpolate between the start and target rotation
+            rotationShaft.transform.localRotation = Quaternion.Lerp(startRotation, targetRotation, normalizedProgress);
+
             yield return null;
         }
 
-        rotationShaft.transform.localRotation = targetQuaternion;
+        // After the rotation is complete, ensure the ramp is set to the target rotation
+        rotationShaft.transform.localRotation = targetRotation;
     }
 
     private IEnumerator ElevationVisualization()

--- a/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
@@ -154,171 +154,6 @@ public class RampPresenter : MonoBehaviour
         }
     }
 
-    // private float SmoothInterpolationFactor(
-    //     float t,
-    //     float totalTime,
-    //     float timeToMaxSpeed,
-    //     float constantSpeedRatio,
-    //     float maxRotationSpeed,
-    //     float acceleration
-    //     )
-    // {
-    //     float accelerationPhase = timeToMaxSpeed / totalTime;
-    //     float decelerationPhase = accelerationPhase;
-    //     float constantSpeedPhase = constantSpeedRatio;
-
-    //     // Acceleration phase
-    //     if (t < accelerationPhase)
-    //     {            
-    //         return 0.5f * acceleration * t * t / (accelerationPhase * accelerationPhase);
-    //     }
-    //     // Constant speed phase
-    //     else if (t < accelerationPhase + constantSpeedPhase)
-    //     {
-    //         return accelerationPhase * 0.5f + (t - accelerationPhase);
-    //     }
-    //     // Deceleration phase
-    //     else
-    //     {            
-    //         float decelerationT = (t - (accelerationPhase + constantSpeedPhase)) / decelerationPhase;
-    //         return (accelerationPhase * 0.5f + constantSpeedPhase) 
-    //                 + (decelerationT - 0.5f * acceleration * decelerationT * decelerationT / (maxRotationSpeed * maxRotationSpeed))
-    //                 * decelerationPhase;
-    //     }
-    // }
-    // private IEnumerator RotationVisualization()
-    // {
-    //     // Compute starting, end, and trajectory rotation
-    //     Quaternion startRotation = rotationShaft.transform.localRotation;
-    //     Quaternion targetRotation = Quaternion.Euler(rotationShaft.transform.localEulerAngles.x, _model.RampRotation, rotationShaft.transform.localEulerAngles.z);
-    //     float rotationAngle = Quaternion.Angle(startRotation, targetRotation);
-
-    //     // Convert speed to [deg/sec] and acceleration to [deg/sec^2]
-    //     float scaledSpeed = _model.ScaleRotationSpeed(_rotationSpeed);
-    //     float scaledAcceleration = _model.ScaleRotationAcceleration();
-        
-    //     // Calculate the time to reach maximum speed
-    //     float timeToMaxSpeed = scaledSpeed / scaledAcceleration;
-
-    //     // Calculate the distance covered during acceleration and deceleration
-    //     float distanceToMaxSpeed = 0.5f * scaledAcceleration * Mathf.Pow(timeToMaxSpeed, 2);
-
-    //     // Check if the rotation can reach maximum speed
-    //     float totalTime;
-    //     if (rotationAngle < 2 * distanceToMaxSpeed)
-    //     {
-    //         // If the rotation angle is too small to reach max speed, calculate the time needed for a triangular velocity profile
-    //         totalTime = Mathf.Sqrt(4 * rotationAngle / scaledAcceleration);
-    //     }
-    //     else
-    //     {
-    //         // If the rotation angle is large enough, calculate the time needed for a trapezoidal velocity profile
-    //         float distanceAtConstantSpeed = rotationAngle - 2 * distanceToMaxSpeed;
-    //         float timeAtConstantSpeed = distanceAtConstantSpeed / scaledSpeed;
-    //         totalTime = 2 * timeToMaxSpeed + timeAtConstantSpeed;
-    //     }
-
-    //     Debug.Log("Rotation angle: " + rotationAngle);
-    //     Debug.Log("Scaled speed: " + scaledSpeed);
-    //     Debug.Log("Total time to rotate: " + totalTime);
-
-    //     // Variable to store the current time
-    //     float elapsedTime = 0f;
-
-    //     float currentSpeed = 0f;
-    //     float currentAngle = 0f;
-
-    //     // Rotate the ramp
-    //     while (elapsedTime < totalTime)
-    //     {
-    //         elapsedTime += Time.deltaTime;
-    //         float t = elapsedTime / totalTime;
-
-    //         // Calculate the current speed with acceleration and deceleration
-    //         if (t < 0.5f)
-    //         {
-    //             // Accelerate
-    //             currentSpeed += scaledAcceleration * Time.deltaTime;
-    //         }
-    //         else
-    //         {
-    //             // Decelerate
-    //             currentSpeed -= scaledAcceleration * Time.deltaTime;
-    //         }
-    //         currentSpeed = Mathf.Max(currentSpeed, 0f);
-
-    //         // Calculate the current angle
-    //         currentAngle += currentSpeed * Time.deltaTime;
-
-    //         // Interpolate between the start and target rotation
-    //         rotationShaft.transform.localRotation = Quaternion.Lerp(startRotation, targetRotation, currentAngle / rotationAngle);
-
-    //         yield return null;
-    //     }
-    // }
-
-    // private IEnumerator RotationVisualization()
-    // {
-    //     // Store the starting rotation
-    //     Quaternion startRotation = rotationShaft.transform.localRotation;
-    //     // Store the target rotation based on the model.RampRotation value
-    //     Quaternion targetRotation = Quaternion.Euler(rotationShaft.transform.localEulerAngles.x, _model.RampRotation, rotationShaft.transform.localEulerAngles.z);
-
-    //     // Calculate the angle between the start and target rotations
-    //     float rotationAngle = Quaternion.Angle(startRotation, targetRotation);
-
-    //     // Get the scaled rotation speed and convert it to degrees per second
-    //     float scaledSpeed = _model.ScaleRotationSpeed(_rotationSpeed);
-
-    //     // Define the acceleration in steps/sec² and scale it
-    //     float scaledAcceleration = _model.ScaleRotationAcceleration();
-    //     Debug.Log("Scaled acceleration: " + scaledAcceleration);
-
-    //     // Calculate the total time it will take to rotate
-    //     float totalTime = rotationAngle / scaledSpeed;
-    //     Debug.Log("Rotation angle: " + rotationAngle);
-    //     Debug.Log("Scaled speed: " + scaledSpeed);
-    //     Debug.Log("Total time to rotate: " + totalTime);
-    //     // Variable to store the current time
-    //     float elapsedTime = 0f;
-
-    //     float currentSpeed = 0f;
-    //     float currentAngle = 0f;
-
-    //     // Rotate the ramp
-    //     while (elapsedTime < totalTime)
-    //     {
-    //         elapsedTime += Time.deltaTime;
-    //         float t = elapsedTime / totalTime;
-    //         // float easeInOutFactor = t * t * (3f - 2f * t); // Smoothstep function
-    //         // Calculate the current speed with acceleration and deceleration
-    //         if (t < 0.5f)
-    //         {
-    //             // Accelerate
-    //             currentSpeed += scaledAcceleration * Time.deltaTime;
-    //         }
-    //         else
-    //         {
-    //             // Decelerate
-    //             currentSpeed -= scaledAcceleration * Time.deltaTime;
-    //         }
-    //         currentSpeed = Mathf.Max(currentSpeed, 0f);
-
-    //         // Calculate the current speed with acceleration
-    //         // float currentSpeed = scaledSpeed * easeInOutFactor;
-    //         // float currentAngle = currentSpeed * elapsedTime + 0.5f * scaledAcceleration * Mathf.Pow(elapsedTime, 2);
-    //         currentAngle += currentSpeed * Time.deltaTime;
-
-    //         // Interpolate between the start and target rotation
-    //         rotationShaft.transform.localRotation = Quaternion.Lerp(startRotation, targetRotation, currentAngle / _model.RampRotation);
-
-    //         yield return null;
-    //     }
-
-    //     // After the rotation is complete, ensure the ramp is set to the target rotation
-    //     rotationShaft.transform.localRotation = targetRotation;
-    // }
-
     private IEnumerator ElevationVisualization()
     {
         // Store the starting elevation
@@ -338,10 +173,9 @@ public class RampPresenter : MonoBehaviour
 
         // Get the scaled elevation speed and convert it to m/s (from inches/s)
         float scaledSpeed = _model.ScaleElevationSpeed(_elevationSpeed);
-        float convertedSpeed = scaledSpeed * 0.0254f;
 
         // Calculate the total time it will take to elevate
-        float totalTime = elevationDistance / convertedSpeed;
+        float totalTime = elevationDistance / scaledSpeed;
         // Variable to store the time
         float elapsedTime = 0f;
 
@@ -351,16 +185,13 @@ public class RampPresenter : MonoBehaviour
             elapsedTime += Time.deltaTime;
 
             // Interpolation factor to smooth out the elevation
-            float normalizedProgress = Mathf.SmoothStep(0f, 1f, (Mathf.Clamp01(elapsedTime / totalTime)));
+            float normalizedProgress = Mathf.SmoothStep(0f, 1f, Mathf.Clamp01(elapsedTime / totalTime));
 
             // Interpolate between the start and target elevation
             elevationMechanism.transform.localPosition = Vector3.Lerp(startElevation, targetElevation, normalizedProgress);
 
             yield return null;
         }
-
-        // After the elevation is complete, ensure the ramp is set to the target elevation
-        elevationMechanism.transform.localPosition = targetElevation;
     }
 
     private void ResetRampWhenPlayModeChanges()

--- a/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
@@ -109,8 +109,8 @@ public class RampPresenter : MonoBehaviour
         {
             elapsedTime += Time.deltaTime;
 
-            // Interpolation factor
-            float normalizedProgress = Mathf.Clamp01(elapsedTime / totalTime);
+            // Interpolation factor to smooth out the rotation
+            float normalizedProgress = Mathf.SmoothStep(0f, 1f, (Mathf.Clamp01(elapsedTime / totalTime)));
 
             // Interpolate between the start and target rotation
             rotationShaft.transform.localRotation = Quaternion.Lerp(startRotation, targetRotation, normalizedProgress);

--- a/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
@@ -124,25 +124,45 @@ public class RampPresenter : MonoBehaviour
 
     private IEnumerator ElevationVisualization()
     {
-        Vector3 currentElevation = elevationMechanism.transform.localPosition;
-        //Debug.Log($"model.RampElevation value: {model.RampElevation}");
-        float elevationScalar = ElevationVisualizationMin + (_model.RampElevation / 100f) * (ElevationVisualizationMax - ElevationVisualizationMin); // Convert percent elevation to its scalar value
-        
-        //Make sure the elevation is within the min and max elevation bounds
+        // Store the starting elevation
+        Vector3 startElevation = elevationMechanism.transform.localPosition;
+
+        // Convert percent elevation from model.RampElevation to its scalar value
+        float elevationScalar = ElevationVisualizationMin + (_model.RampElevation / 100f) * (ElevationVisualizationMax - ElevationVisualizationMin);
+
+        // Make sure the elevation is within the min and max elevation bounds
         elevationScalar = Mathf.Clamp(elevationScalar, ElevationVisualizationMin, ElevationVisualizationMax);
 
-        Vector3 targetElevation = elevationDirection * elevationScalar;   
-        
-        while (Vector3.Distance(currentElevation, targetElevation) > 0.001f)
+        // Store the target elevation
+        Vector3 targetElevation = elevationDirection * elevationScalar;
+
+        // Calculate the distance between the start and target elevations
+        float elevationDistance = Vector3.Distance(startElevation, targetElevation);
+
+        // Get the scaled elevation speed and convert it to m/s (from inches/s)
+        float scaledSpeed = _model.ScaleElevationSpeed(_elevationSpeed);
+        float convertedSpeed = scaledSpeed * 0.0254f;
+
+        // Calculate the total time it will take to elevate
+        float totalTime = elevationDistance / convertedSpeed;
+        // Variable to store the time
+        float elapsedTime = 0f;
+
+        // Elevate the ramp
+        while (elapsedTime < totalTime)
         {
-            // Calculate the scaled speed for elevation
-            // Max speed: 2 inches/sec
-            float scaledSpeed = _model.ScaleElevationSpeed(_elevationSpeed);
-            currentElevation = Vector3.Lerp(currentElevation, targetElevation, scaledSpeed * Time.deltaTime);
-            elevationMechanism.transform.localPosition = currentElevation;
+            elapsedTime += Time.deltaTime;
+
+            // Interpolation factor
+            float normalizedProgress = Mathf.Clamp01(elapsedTime / totalTime);
+
+            // Interpolate between the start and target elevation
+            elevationMechanism.transform.localPosition = Vector3.Lerp(startElevation, targetElevation, normalizedProgress);
+
             yield return null;
         }
 
+        // After the elevation is complete, ensure the ramp is set to the target elevation
         elevationMechanism.transform.localPosition = targetElevation;
     }
 

--- a/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
@@ -152,6 +152,9 @@ public class RampPresenter : MonoBehaviour
             
             yield return null;
         }
+
+        // Ensure the final rotation matches exactly
+        rotationShaft.transform.localRotation = endQuaternion;
     }
 
     private IEnumerator ElevationVisualization()
@@ -191,6 +194,9 @@ public class RampPresenter : MonoBehaviour
 
             yield return null;
         }
+
+        // Ensure the final elevation matches exactly
+        elevationMechanism.transform.localPosition = targetElevation;
     }
 
     private void ResetRampWhenPlayModeChanges()

--- a/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
@@ -161,8 +161,6 @@ public class RampPresenter : MonoBehaviour
 
         // Convert percent elevation from model.RampElevation to its scalar value
         float elevationScalar = ElevationVisualizationMin + (_model.RampElevation / 100f) * (ElevationVisualizationMax - ElevationVisualizationMin);
-
-        // Make sure the elevation is within the min and max elevation bounds
         elevationScalar = Mathf.Clamp(elevationScalar, ElevationVisualizationMin, ElevationVisualizationMax);
 
         // Store the target elevation
@@ -171,7 +169,7 @@ public class RampPresenter : MonoBehaviour
         // Calculate the distance between the start and target elevations
         float elevationDistance = Vector3.Distance(startElevation, targetElevation);
 
-        // Get the scaled elevation speed and convert it to m/s (from inches/s)
+        // Get the 8-bit PWM speed and convert it to m/s
         float scaledSpeed = _model.ScaleElevationSpeed(_elevationSpeed);
 
         // Calculate the total time it will take to elevate
@@ -185,7 +183,8 @@ public class RampPresenter : MonoBehaviour
             elapsedTime += Time.deltaTime;
 
             // Interpolation factor to smooth out the elevation
-            float normalizedProgress = Mathf.SmoothStep(0f, 1f, Mathf.Clamp01(elapsedTime / totalTime));
+            // float normalizedProgress = Mathf.SmoothStep(0f, 1f, Mathf.Clamp01(elapsedTime / totalTime));
+            float normalizedProgress = elapsedTime / totalTime;
 
             // Interpolate between the start and target elevation
             elevationMechanism.transform.localPosition = Vector3.Lerp(startElevation, targetElevation, normalizedProgress);

--- a/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
@@ -89,7 +89,6 @@ public class RampPresenter : MonoBehaviour
     {
         // Store the starting rotation
         Quaternion startRotation = rotationShaft.transform.localRotation;
-        // Store the target rotation based on the model.RampRotation value
         Quaternion targetRotation = Quaternion.Euler(rotationShaft.transform.localEulerAngles.x, _model.RampRotation, rotationShaft.transform.localEulerAngles.z);
 
         // Calculate the angle between the start and target rotations
@@ -98,15 +97,35 @@ public class RampPresenter : MonoBehaviour
         // Get the scaled rotation speed and convert it to degrees per second
         float scaledSpeed = _model.ScaleRotationSpeed(_rotationSpeed);
 
-        // Define the acceleration in steps/sec² and scale it
+        // Define the acceleration in deg/sec² and scale it
         float scaledAcceleration = _model.ScaleRotationAcceleration();
         Debug.Log("Scaled acceleration: " + scaledAcceleration);
 
-        // Calculate the total time it will take to rotate
-        float totalTime = rotationAngle / scaledSpeed;
+        // Calculate the time to reach maximum speed
+        float timeToMaxSpeed = scaledSpeed / scaledAcceleration;
+
+        // Calculate the distance covered during acceleration and deceleration
+        float distanceToMaxSpeed = 0.5f * scaledAcceleration * Mathf.Pow(timeToMaxSpeed, 2);
+
+        // Check if the rotation can reach maximum speed
+        float totalTime;
+        if (rotationAngle < 2 * distanceToMaxSpeed)
+        {
+            // If the rotation angle is too small to reach max speed, calculate the time needed for a triangular velocity profile
+            totalTime = Mathf.Sqrt(4 * rotationAngle / scaledAcceleration);
+        }
+        else
+        {
+            // If the rotation angle is large enough, calculate the time needed for a trapezoidal velocity profile
+            float distanceAtConstantSpeed = rotationAngle - 2 * distanceToMaxSpeed;
+            float timeAtConstantSpeed = distanceAtConstantSpeed / scaledSpeed;
+            totalTime = 2 * timeToMaxSpeed + timeAtConstantSpeed;
+        }
+
         Debug.Log("Rotation angle: " + rotationAngle);
         Debug.Log("Scaled speed: " + scaledSpeed);
         Debug.Log("Total time to rotate: " + totalTime);
+
         // Variable to store the current time
         float elapsedTime = 0f;
 
@@ -118,7 +137,7 @@ public class RampPresenter : MonoBehaviour
         {
             elapsedTime += Time.deltaTime;
             float t = elapsedTime / totalTime;
-            // float easeInOutFactor = t * t * (3f - 2f * t); // Smoothstep function
+
             // Calculate the current speed with acceleration and deceleration
             if (t < 0.5f)
             {
@@ -132,22 +151,77 @@ public class RampPresenter : MonoBehaviour
             }
             currentSpeed = Mathf.Max(currentSpeed, 0f);
 
-            // Calculate the current speed with acceleration
-            // float currentSpeed = scaledSpeed * easeInOutFactor;
-            // float currentAngle = currentSpeed * elapsedTime + 0.5f * scaledAcceleration * Mathf.Pow(elapsedTime, 2);
+            // Calculate the current angle
             currentAngle += currentSpeed * Time.deltaTime;
 
             // Interpolate between the start and target rotation
-            Debug.Log("Current angle: " + currentAngle);
-            float normalizedAngle = Mathf.Clamp01(currentAngle / rotationAngle);
-            rotationShaft.transform.localRotation = Quaternion.Lerp(startRotation, targetRotation, normalizedAngle);
+            rotationShaft.transform.localRotation = Quaternion.Lerp(startRotation, targetRotation, currentAngle / rotationAngle);
 
             yield return null;
         }
-
-        // After the rotation is complete, ensure the ramp is set to the target rotation
-        rotationShaft.transform.localRotation = targetRotation;
     }
+
+    // private IEnumerator RotationVisualization()
+    // {
+    //     // Store the starting rotation
+    //     Quaternion startRotation = rotationShaft.transform.localRotation;
+    //     // Store the target rotation based on the model.RampRotation value
+    //     Quaternion targetRotation = Quaternion.Euler(rotationShaft.transform.localEulerAngles.x, _model.RampRotation, rotationShaft.transform.localEulerAngles.z);
+
+    //     // Calculate the angle between the start and target rotations
+    //     float rotationAngle = Quaternion.Angle(startRotation, targetRotation);
+
+    //     // Get the scaled rotation speed and convert it to degrees per second
+    //     float scaledSpeed = _model.ScaleRotationSpeed(_rotationSpeed);
+
+    //     // Define the acceleration in steps/sec² and scale it
+    //     float scaledAcceleration = _model.ScaleRotationAcceleration();
+    //     Debug.Log("Scaled acceleration: " + scaledAcceleration);
+
+    //     // Calculate the total time it will take to rotate
+    //     float totalTime = rotationAngle / scaledSpeed;
+    //     Debug.Log("Rotation angle: " + rotationAngle);
+    //     Debug.Log("Scaled speed: " + scaledSpeed);
+    //     Debug.Log("Total time to rotate: " + totalTime);
+    //     // Variable to store the current time
+    //     float elapsedTime = 0f;
+
+    //     float currentSpeed = 0f;
+    //     float currentAngle = 0f;
+
+    //     // Rotate the ramp
+    //     while (elapsedTime < totalTime)
+    //     {
+    //         elapsedTime += Time.deltaTime;
+    //         float t = elapsedTime / totalTime;
+    //         // float easeInOutFactor = t * t * (3f - 2f * t); // Smoothstep function
+    //         // Calculate the current speed with acceleration and deceleration
+    //         if (t < 0.5f)
+    //         {
+    //             // Accelerate
+    //             currentSpeed += scaledAcceleration * Time.deltaTime;
+    //         }
+    //         else
+    //         {
+    //             // Decelerate
+    //             currentSpeed -= scaledAcceleration * Time.deltaTime;
+    //         }
+    //         currentSpeed = Mathf.Max(currentSpeed, 0f);
+
+    //         // Calculate the current speed with acceleration
+    //         // float currentSpeed = scaledSpeed * easeInOutFactor;
+    //         // float currentAngle = currentSpeed * elapsedTime + 0.5f * scaledAcceleration * Mathf.Pow(elapsedTime, 2);
+    //         currentAngle += currentSpeed * Time.deltaTime;
+
+    //         // Interpolate between the start and target rotation
+    //         rotationShaft.transform.localRotation = Quaternion.Lerp(startRotation, targetRotation, currentAngle / _model.RampRotation);
+
+    //         yield return null;
+    //     }
+
+    //     // After the rotation is complete, ensure the ramp is set to the target rotation
+    //     rotationShaft.transform.localRotation = targetRotation;
+    // }
 
     private IEnumerator ElevationVisualization()
     {

--- a/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
@@ -153,8 +153,8 @@ public class RampPresenter : MonoBehaviour
         {
             elapsedTime += Time.deltaTime;
 
-            // Interpolation factor
-            float normalizedProgress = Mathf.Clamp01(elapsedTime / totalTime);
+            // Interpolation factor to smooth out the elevation
+            float normalizedProgress = Mathf.SmoothStep(0f, 1f, (Mathf.Clamp01(elapsedTime / totalTime)));
 
             // Interpolate between the start and target elevation
             elevationMechanism.transform.localPosition = Vector3.Lerp(startElevation, targetElevation, normalizedProgress);


### PR DESCRIPTION
This is to fix [Issue 88](https://github.com/kirtonBCIlab/boccia-bci/issues/88)

**Issue Description**

- The implementation of the LERP methods for the ramp rotation and elevation visualizations needs to be improved.
- For example, the ramp would rotate almost to the new location, but then it would take a while to actually finish the movement due to the LERP methods being implemented iteratively. Instead, it needs to interpolate from the start to the end rotation.
- Also, the rotation visualization needs to take into account the acceleration and deceleration of the ramp as it rotates in order to be realistic.

**Changes**

- For both rotation and elevation, interpolation is performed from the starting position to the target position. The time required for this is calculated based on the set speed, and the rotation angle/elevation distance.
- Implemented acceleration and deceleration phases for the rotation visualization. 

**Testing**

- Use the fan to rotate and elevate the ramp. You should observe that the ramp rotates realistically with acceleration and deceleration, and completes the movement in a reasonable amount of time (instead of taking longer to actually complete as it gets to the target position).