### PR TITLE
Rotate ramp to the center of fan segments

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanInteractions.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanInteractions.cs
@@ -120,10 +120,20 @@ public class FanInteractions : MonoBehaviour, IPointerClickHandler
         float rotationAngle = 0f;
         float elevation = 50f;
 
-        // Calculate the rotation angle and elevation based on the number of columns and rows        
+        float threshold = 1e-5f;
+
+        // Calculate the rotation angle and elevation based on the number of columns and rows       
         if (_fanSettings.NColumns > 1)
         {
-            rotationAngle = - _fanSettings.Theta / 2 + columnIndex * (_fanSettings.Theta / (_fanSettings.NColumns - 1));
+            float segmentAngle = _fanSettings.Theta / _fanSettings.NColumns;
+            // Calculate rotation angle and add half of the segment angle to center the ramp in the segment
+            rotationAngle = (- _fanSettings.Theta / 2) + (columnIndex * segmentAngle) + (segmentAngle / 2);
+            
+            // Avoid unnecessarily small numbers due to rounding
+            if (Mathf.Abs(rotationAngle) < threshold)
+            {
+                rotationAngle = 0f;
+            }
         }
 
         if (_fanSettings.NRows > 1)

--- a/Boccia-Unity/Assets/Boccia/BCI/FanInteractions.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanInteractions.cs
@@ -117,8 +117,8 @@ public class FanInteractions : MonoBehaviour, IPointerClickHandler
         int rowIndex = _fanSettings.NRows - 1 - (segmentID % _fanSettings.NRows);
 
         // Initialize values to starting position of the ramp
-        float rotationAngle = 0f;
-        float elevation = 50f;
+        float rotationAngle = _model.RampSettings.RotationOrigin;
+        float elevation = _model.RampSettings.ElevationOrigin;
 
         float threshold = 1e-5f;
 

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -58,6 +58,7 @@ public class HardwareRamp : RampController, ISerialController
 
     public void RotateBy(float degrees)
     {
+        // Relative rotation
         Rotation += degrees;
         
         if (_wasRotationClamped) 
@@ -72,6 +73,7 @@ public class HardwareRamp : RampController, ISerialController
 
     public void RotateTo(float degrees)
     {
+        // Absolute rotation
         Rotation = degrees;
         // Rotation = Mathf.Clamp(degrees, MinRotation, MaxRotation);
         AddSerialCommandToList($"ra{Rotation.ToString("0")}");
@@ -81,7 +83,7 @@ public class HardwareRamp : RampController, ISerialController
 
     public void ElevateBy(float elevation)
     {
-        //Old Way
+        // Relative elevation
         Elevation += elevation;
         
         if (_wasElevationClamped) 
@@ -96,7 +98,7 @@ public class HardwareRamp : RampController, ISerialController
 
     public void ElevateTo(float elevation)
     {
-        //Old Way
+        // Absolute elevation
         Elevation = elevation;
         // Clamped to Max/Min Elevation
         // Elevation = Mathf.Clamp(elevation, _minElevation, _maxElevation);

--- a/Boccia-Unity/Assets/Boccia/Model/SimulatedRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/SimulatedRamp.cs
@@ -43,6 +43,7 @@ public class SimulatedRamp : RampController
 
     public void RotateBy(float degrees)
     {
+        // Relative rotation
         Rotation += degrees;
         //Debug.Log($"Simulated rotation by: {Rotation}");
         SendChangeEvent();
@@ -50,6 +51,7 @@ public class SimulatedRamp : RampController
 
     public void RotateTo(float degrees)
     {
+        // Absolute rotation
         Rotation = degrees;
         //Debug.Log($"Simulated rotation to: {Rotation}");
         SendChangeEvent();
@@ -57,6 +59,7 @@ public class SimulatedRamp : RampController
 
     public void ElevateBy(float elevation)
     {
+        // Relative elevation
         Elevation += elevation;
         //Debug.Log($"Simulated elevation by: {Elevation}");
         SendChangeEvent();
@@ -64,6 +67,7 @@ public class SimulatedRamp : RampController
 
     public void ElevateTo(float elevation)
     {
+        // Absolute elevation
         Elevation = elevation;
         // Debug.Log($"Simulated elevation to: {Elevation}");
         SendChangeEvent();


### PR DESCRIPTION
This will fix [Issue 96](https://github.com/kirtonBCIlab/boccia-bci/issues/96).

**Description**

- The ramp did not rotate to align with the center of the fan segments
- For an odd number of coarse fan columns, the ramp aligned with the left or right edge of the segment (depending on the direction of rotation). It only aligned with the center of the segment for `rotationAngle = 0`.
- For an even number of coarse fan columns, the ramp's rotation angle was not calculated properly and the ramp did not align with the center of the segments.

**Changes**

- Calculated the angle (`segmentAngle`) of each "slice" in the fan based on the value of theta and the number of columns.
- Used `segmentAngle` to calculate the rotation angle for the clicked segment. The `rotationAngle` calculation included adding half the value of `segmentAngle` to align the ramp with the center of the segment.

**Testing**

- In `main`, observe that the ramp does not align with the center of the fan segment when rotating. Click any segment of the coarse fan (other than the center segment). Once the fan is done rotating, select the back button to observe that the ramp is aligned with the edge of the coarse fan segment, and not the center. 
- In this branch (`96-ramp-alignment-with-fan-segment`), rotate the ramp, then switch back to the coarse fan. You should see that the ramp aligns with the center of the segment it rotated to. If needed, switch from Game view into Scene view to observe the alignment of the ramp from a different angle to verify that it is aligned with the segment's center.
- The ramp should always rotate to align with the center for each segment, regardless of the number of columns. 