### PR TITLE
Fix issues with the Random Ball process

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
@@ -39,6 +39,7 @@ public class FanPresenter : MonoBehaviour
         _model.NavigationChanged += NavigationChanged;
         _model.WasChanged += UpdateFineFan;
         _model.ResetFan += ResetFanWhenRampResets;
+        _model.RandomBall += HandleFanForRandomBall;
 
         _originalRotation = transform.rotation;
 
@@ -211,13 +212,26 @@ public class FanPresenter : MonoBehaviour
         }
     }
 
+    /// <summary>
+    ///  Resets the fan positioning mode if needed
+    ///  Generates a coarse fan
+    /// </summary>
     private void ResetFanWhenRampResets()
     {
         if (positioningMode == FanPositioningMode.CenterToRails)
         {
             positioningMode = FanPositioningMode.CenterToBase;
-            GenerateFanWorkflow();
         }
+
+        DisplayFanOnCorrespondingScreen();
+    }
+
+    // <summary>
+    // Remove the fan when the ramp moves to the random position
+    // </summary>
+    private void HandleFanForRandomBall()
+    {
+        fanGenerator.DestroyFanSegments();
     }
 
     /// <summary>

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -69,6 +69,7 @@ public class BocciaModel : Singleton<BocciaModel>
     public event System.Action NavigationChanged;
     public event System.Action BciChanged;
     public event System.Action NewRandomJack;
+    public event System.Action RandomBall;
     public event System.Action BallResetChanged;
 
     public event System.Action ResetTails;
@@ -301,7 +302,12 @@ public class BocciaModel : Singleton<BocciaModel>
     public void SendSerialCommandList() => _hardwareRamp.SendSerialCommandList();
     public void ResetSerialCommands() => _hardwareRamp.ResetSerialCommands();
     public Task<string> ReadSerialCommandAsync() => _hardwareRamp.ReadSerialCommandAsync();
-    public void RandomBallDrop(int randomRotation, int randomElevation) => _hardwareRamp.RandomBallDrop(randomRotation, randomElevation);
+
+    public void RandomBallDrop(int randomRotation, int randomElevation) 
+    {
+        _hardwareRamp.RandomBallDrop(randomRotation, randomElevation);
+        SendRandomBallEvent();
+    }
 
     // Method to reset the state of the bar after the ball has been dropped
     public void ResetBar()
@@ -535,6 +541,11 @@ public class BocciaModel : Singleton<BocciaModel>
     private void SendRandomJackEvent()
     {
         NewRandomJack?.Invoke();
+    }
+
+    private void SendRandomBallEvent()
+    {
+        RandomBall?.Invoke();
     }
 
     private void SendNavigationChangeEvent()

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -115,7 +115,6 @@ public class BallPresenter : MonoBehaviour
                 // Call the method to log the drop position and rotation
                 // and the rest of the ball drop code
                 DropBall();
-                BallDropped?.Invoke(_activeBall);
             }
         }
     }
@@ -179,6 +178,9 @@ public class BallPresenter : MonoBehaviour
         {
             yield return null;
         }
+
+        // Send the event to spawn the tail now that the ball is rolling
+        BallDropped?.Invoke(_activeBall);
 
         // Velocity threshold
         while (_ballRigidbody.velocity.magnitude > 0.01f)

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -138,13 +138,13 @@ public class PlayScreenPresenter : MonoBehaviour
     }
 
     private IEnumerator WaitForStopBeforeRampReset()
-    {  
+    { 
         while (_model.IsRampMoving)
         {
             yield return null;
         }
-
-        _model.ResetRampPosition();
+        
+        ResetRamp();
     }
 
 


### PR DESCRIPTION
This will fix [Issue 104](https://github.com/kirtonBCIlab/boccia-bci/issues/104)

**Description**
Some aspects of the Random Ball process in the Play screen did not follow normal behaviors.
- The fan was still visible while the ramp moved to the random position and back.
- The ball tail was generated before the ball had been released.


**Changes**

- An event action when `RandomBall` is pressed triggers `FanPresenter` to remove the fan when the ramp moves to the random location. 
- The `ResetFanWhenRampResets()` method was slightly modified to also reset the fan when the ramp resets as part of the Random Ball process.
- In `BallPresenter`, the event to trigger the ball tail was moved to be called _after_ the ball starts rolling on the floor.


**Testing**

In the Play screen, click the `RandomBall` button. You should observe that:

- There is no fan displayed while the ramp is in motion, similar to normal behavior.
- The ball tail only spawns after the ball has started rolling on the floor.