### PR TITLE
Avoid sending redundant serial commands

### DIFF
--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -67,8 +67,19 @@ public class HardwareRamp : RampController, ISerialController
 
     public void RotateBy(float degrees)
     {
+        // Store the previous rotation
+        float previousRotation = Rotation;
+
         // Relative rotation
         Rotation += degrees;
+
+        // Check if target rotation is the same as the previous rotation
+        if (Mathf.Approximately(Rotation, previousRotation))
+        {
+            // If the new rotation is the same, skip sending the serial command
+            // Debug.Log($"Target rotation is the same as the previous rotation.");
+            return;
+        }
         
         if (_wasRotationClamped) 
         { 
@@ -83,6 +94,14 @@ public class HardwareRamp : RampController, ISerialController
 
     public void RotateTo(float degrees)
     {
+        // Check if target rotation is the same as the previous rotation
+        if (Mathf.Approximately(Rotation, degrees))
+        {
+            // If the new rotation is the same, skip sending the serial command
+            // Debug.Log($"Target rotation is the same as the previous rotation.");
+            return;
+        }
+
         // Absolute rotation
         Rotation = degrees;
         // Rotation = Mathf.Clamp(degrees, MinRotation, MaxRotation);
@@ -94,9 +113,20 @@ public class HardwareRamp : RampController, ISerialController
 
     public void ElevateBy(float elevation)
     {
+        // Store the previous elevation
+        float previousElevation = Elevation;
+
         // Relative elevation
         Elevation += elevation;
-        
+
+        // Check if target elevation is the same as the previous elevation
+        if (Mathf.Approximately(Elevation, previousElevation))
+        {
+            // If the new elevation is the same, skip sending the serial command
+            // Debug.Log($"Target elevation is the same as the previous elevation.");
+            return;
+        }
+
         if (_wasElevationClamped) 
         { 
             elevation = 0; 
@@ -110,6 +140,14 @@ public class HardwareRamp : RampController, ISerialController
 
     public void ElevateTo(float elevation)
     {
+        // Check if target elevation is the same as the previous elevation
+        if (Mathf.Approximately(Elevation, elevation))
+        {
+            // If the new elevation is the same, skip sending the serial command
+            // Debug.Log($"Target elevation is the same as the previous elevation.");
+            return;
+        }
+
         // Absolute elevation
         Elevation = elevation;
         // Clamped to Max/Min Elevation


### PR DESCRIPTION
This is to fix [Issue 103](https://github.com/kirtonBCIlab/boccia-bci/issues/103)

**Description**
If the new target elevation or rotation is the same as the current value, we do not need to send a serial command.

**Changes**
In `HardwareRamp.cs`
- In the absolute rotation and elevation methods (`RotateTo()` and `ElevateTo()`), I added a statement to check if the `degrees` or `elevation` parameter passed to the method is the same as the current value of `Rotation` or `Elevation`. If it is true, the code to send a serial command is skipped.
- In the relative rotation and elevation methods (`RotateBy()` and `ElevateBy()`), I added a variable to store the previous `Rotation` or `Elevation` value before updating the value. The previous value is compared to the new target value. If it is the same, the code to send a serial command is skipped. 
- The reason why it is slightly different for the absolute vs. relative methods is because the relative methods needed to account for the clamping of Rotation or Elevation when determining if the target value is the same as the previous. 

**Testing**

- In `HardwareRamp.cs`, uncomment the debug calls for the hardware commands in lines 91, 110, 137, and 157. 
- In the Play screen, use the fan to move the ramp. Select fan segments with the same rotation or elevation as the ramp's current position. Observe that the hardware command debug statements are not called when the target value is the same as the current position.