### PR TITLE
Fix incorrect hardware commands

### DIFF
--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -129,12 +129,13 @@ public class HardwareRamp : RampController, ISerialController
 
         if (_wasElevationClamped) 
         { 
-            elevation = 0; 
+            // Difference between the previous and clamped elevation
+            elevation = Elevation - previousElevation;
             _wasElevationClamped = false;
         }
         AddSerialCommandToList($"er{elevation}");
         _model.SendSerialCommandList();
-        // Debug.Log($"Hardware elevate by: {elevation}");
+        Debug.Log($"Hardware elevate by: {elevation}");
         SendChangeEvent();
     }
 

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -88,7 +88,7 @@ public class HardwareRamp : RampController, ISerialController
         }        
         AddSerialCommandToList($"rr{degrees.ToString("0")}");
         _model.SendSerialCommandList();
-        Debug.Log($"Hardware rotate by: {degrees}");
+        // Debug.Log($"Hardware rotate by: {degrees}");
         SendChangeEvent();
     }
 
@@ -135,7 +135,7 @@ public class HardwareRamp : RampController, ISerialController
         }
         AddSerialCommandToList($"er{elevation}");
         _model.SendSerialCommandList();
-        Debug.Log($"Hardware elevate by: {elevation}");
+        // Debug.Log($"Hardware elevate by: {elevation}");
         SendChangeEvent();
     }
 

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -83,12 +83,12 @@ public class HardwareRamp : RampController, ISerialController
         
         if (_wasRotationClamped) 
         { 
-            degrees = 0; 
+            degrees = Rotation - previousRotation; 
             _wasRotationClamped = false;
         }        
         AddSerialCommandToList($"rr{degrees.ToString("0")}");
         _model.SendSerialCommandList();
-        // Debug.Log($"Hardware rotate by: {degrees}");
+        Debug.Log($"Hardware rotate by: {degrees}");
         SendChangeEvent();
     }
 

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -83,6 +83,7 @@ public class HardwareRamp : RampController, ISerialController
         
         if (_wasRotationClamped) 
         { 
+            // Difference between the previous and clamped rotation
             degrees = Rotation - previousRotation; 
             _wasRotationClamped = false;
         }        


### PR DESCRIPTION
This will fix [Issue 116](https://github.com/kirtonBCIlab/boccia-bci/issues/116).

**Description of the issue**

- Relative rotation or elevation is clamped based on the limits of Rotation and Elevation. Sometimes, relative movement involves rotation or elevation by a non-zero amount before reaching the limit. 
- However, in these situations, the hardware command debug calls report rotation/elevation by 0. See the [issue description](https://github.com/kirtonBCIlab/boccia-bci/issues/116) for a more detailed example.
- The problem has to do with the values that the `RotateBy()` and `ElevateBy()` methods send to the serial and debug calls. 
- For example, the `RotateBy()` method sets degrees = 0 each time the `Rotation` is clamped. However, as described above, there may still be a non-zero rotation before reaching the limit.


**Changes**

In `HardwareRamp.cs`
- When clamping occurs, the value of degrees or elevation sent to the serial is now calculated as the difference between the clamped value and the previous value.
For example: `degrees = Rotation - previousRotation` where `degrees` is the value sent to the ramp, `Rotation` is the clamped value (the minimum/maximum rotation value) and `previousRotation` is the stored value of the Rotation prior to the current movement.
- The value sent to the ramp represents the remaining distance to move before reaching the limit.


**Testing**

- In `HardwareRamp.cs`, uncomment the hardware command debug calls in the `RotateBy()` and `ElevateBy()` methods (lines 92 and 138).
- In Play using the fine fan, rotate or elevate the ramp to reach the limits. 
- You should observe that the relative rotation/elevation value in the debug calls changes to reflect the remaining distance to the limits. 