### PR TITLE
99-reset-the-serial-connection-when-quitting-the-game

### DIFF
--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -457,9 +457,14 @@ public class BocciaModel : Singleton<BocciaModel>
     public void QuitGame()
     {
         UnityEditor.EditorApplication.isPlaying = false;
+        _hardwareRamp.DisconnectFromSerialPort();
         Application.Quit();
     }
 
+    private void OnApplicationQuit()
+    {
+        QuitGame();
+    }
 
     // MARK: BCI control
 

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -266,7 +266,9 @@ public class HardwareRamp : RampController, ISerialController
             try     
             {
                 _serial.Close();
+                _serial.Dispose();
                 serialEnabled = false;
+                // Debug.Log("Serial port closed correctly.");
             }
 
             catch (Exception ex)
@@ -338,5 +340,5 @@ public class HardwareRamp : RampController, ISerialController
     private void SendChangeEvent()
     {
         RampChanged?.Invoke();
-    }
+    }    
 }


### PR DESCRIPTION
# Description
Added method to securely end serial connection when closing play mode.

# Testing
For testting you'll need an Arduino connected to the PC via USB cable.
1. Start the Unity application and navigate to `Start/Play Boccia!`
2. In the Ramp Setup menu, select the appropriate COMPort and connect to it.
3. In VS Code, open a serial monitor terminal (`Win + Shift + P`, then search for "Toggle Serial Monitor")
4. While the serial connection is open in Unity, try to connect to the same port in VS code, this should fail
5. Stop the Unity play mode either by pressing `Quit` in the hamburger menu, or the `Play` button in the Unity editor
6. In VS Code, try to connect to the same port, this should succeed.

# Notes
For checking that the port closed correctly, you can enable like `HardwareRamp:271`