### PR TITLE
Fix disconnect button sizing

### DIFF
--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/RampSetupMenu.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/RampSetupMenu.prefab
@@ -919,7 +919,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1975887960964683369}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -930,7 +930,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: -10.3, y: 0}
   m_SizeDelta: {x: 200, y: 52}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6492310161929581189
@@ -3778,7 +3778,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3306738760973638474, guid: 1b76e374a2c2db841a59b92ea3cb206b, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 200
+      value: 220
       objectReference: {fileID: 0}
     - target: {fileID: 3306738760973638474, guid: 1b76e374a2c2db841a59b92ea3cb206b, type: 3}
       propertyPath: m_SizeDelta.y


### PR DESCRIPTION
This will close [Issue 102](https://github.com/kirtonBCIlab/boccia-bci/issues/102). 

After pressing "Connect" in the Ramp Setup menu, the text switches to "Disconnect" but this text doesn't quite fit on the button background.

**Changes**

- I made the Connect/Disconnect button wider so that the text fits nicer, and shifted the dropdown over for more room.
- To see the change, just navigate to the Ramp Setup menu and press Connect to see that the Disconnect text fits now.