### PR TITLE
Adjust drop bar timing

### DIFF
--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -12,13 +12,16 @@ public class BallPresenter : MonoBehaviour
     private GameObject _activeBall; // Refers the the ball currently in use for each shot
     private int _ballCount = 0;
     private Rigidbody _ballRigidbody;
-    //private float _ballHeightThreshold = 1.0f;
 
     // References for the ramp components
     public GameObject dropBar;
     public GameObject elevationPlate;
     private Animator _barAnimation;
     public GameObject rampBase;
+
+    // Variables for the bar animation timing
+    private float _dropBarWaitTime = 4f;
+    private float _dropBarClosingTime = 6f;
 
     // Variables for storing the ball transform
     private Vector3 _dropPosition;
@@ -132,7 +135,7 @@ public class BallPresenter : MonoBehaviour
 
         // Bar opening and closing animation
         _barAnimation.SetBool("isOpening", true);
-        yield return new WaitForSecondsRealtime(3f);
+        yield return new WaitForSecondsRealtime(_dropBarWaitTime);
         _barAnimation.SetBool("isOpening", false);
 
         // Call the method to reset the Model's bar state
@@ -141,7 +144,7 @@ public class BallPresenter : MonoBehaviour
 
         // Wait for the bar to fully close
         // Before setting the ramp to not moving
-        yield return new WaitForSecondsRealtime(3f);
+        yield return new WaitForSecondsRealtime(_dropBarClosingTime);
         _model.SetRampMoving(false);
 
         yield return null;

--- a/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/BallPresenter.cs
@@ -132,7 +132,7 @@ public class BallPresenter : MonoBehaviour
 
         // Bar opening and closing animation
         _barAnimation.SetBool("isOpening", true);
-        yield return new WaitForSecondsRealtime(1f);
+        yield return new WaitForSecondsRealtime(3f);
         _barAnimation.SetBool("isOpening", false);
 
         // Call the method to reset the Model's bar state

--- a/Boccia-Unity/Assets/Boccia/Ramp/Drop Bar Animation/Drop Bar axis corrector.controller
+++ b/Boccia-Unity/Assets/Boccia/Ramp/Drop Bar Animation/Drop Bar axis corrector.controller
@@ -62,7 +62,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: DropBarClosing
-  m_Speed: 1
+  m_Speed: 0.25
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -814479691002607019}


### PR DESCRIPTION
This will close [Issue 101](https://github.com/kirtonBCIlab/boccia-bci/issues/101)

**Description:**

The timing of the drop bar animation in Unity is faster than the real drop bar movement.


**Changes:**

- Slowed down the bar closing animation. Note: I did not also slow down the bar opening clip, because if the bar moves too slowly, it doesn't properly release the ball.
- Increased the wait time between the bar opening and closing animation clips so that the overall timing better matches the real bar.


**Testing:**

- In Play or Virtual Play, click the drop button to see the changes to the drop bar animation. The overall timing is slower than it was before.