### PR TITLE
118-sweeping-mode-in-play

### DIFF
--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -290,6 +290,7 @@ public class BocciaModel : Singleton<BocciaModel>
     public void SetRotation(float degrees) => _rampController.SetRotation(degrees);
     public void ElevateBy(float elevation) => _rampController.ElevateBy(elevation);
     public void ElevateTo(float elevation) => _rampController.ElevateTo(elevation);
+    public void SetElevation(float degrees) => _rampController.SetElevation(degrees);
 
     public void RotationSweep(int direction) => _hardwareRamp.RotationSweep(direction);
     public void ElevationSweep(int direction) => _hardwareRamp.ElevateSweep(direction);

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -29,6 +29,8 @@ public class BocciaModel : Singleton<BocciaModel>
     private RampController _simulatedRamp;
     private HardwareRamp _hardwareRamp;
 
+    public float CurrentRotationAngle { get; set; }
+
     public float RampRotation => _rampController.Rotation;
     public float RampElevation => _rampController.Elevation;
     public bool BarState => _rampController.IsBarOpen;
@@ -286,6 +288,9 @@ public class BocciaModel : Singleton<BocciaModel>
     public void RotateTo(float degrees) => _rampController.RotateTo(degrees);
     public void ElevateBy(float elevation) => _rampController.ElevateBy(elevation);
     public void ElevateTo(float elevation) => _rampController.ElevateTo(elevation);
+
+    public void RotationSweep(int direction) => _hardwareRamp.RotationSweep(direction);
+    public void ElevationSweep(int direction) => _hardwareRamp.ElevateSweep(direction);
 
     public float ScaleRotationSpeed(float speed) => _hardwareRamp.ScaleRotationSpeed(speed);
     public float ScaleRotationAcceleration() => _hardwareRamp.ScaleRotationAcceleration();

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -35,6 +35,7 @@ public class BocciaModel : Singleton<BocciaModel>
     public float RampElevation => _rampController.Elevation;
     public bool BarState => _rampController.IsBarOpen;
     public bool IsRampMoving => _rampController.IsMoving;
+    public bool IsSweeping => _rampController.IsSweeping;
     
     public BocciaBallState BallState;
 
@@ -286,6 +287,7 @@ public class BocciaModel : Singleton<BocciaModel>
     // MARK: Game control
     public void RotateBy(float degrees) => _rampController.RotateBy(degrees);
     public void RotateTo(float degrees) => _rampController.RotateTo(degrees);
+    public void SetRotation(float degrees) => _rampController.SetRotation(degrees);
     public void ElevateBy(float elevation) => _rampController.ElevateBy(elevation);
     public void ElevateTo(float elevation) => _rampController.ElevateTo(elevation);
 
@@ -307,6 +309,12 @@ public class BocciaModel : Singleton<BocciaModel>
     public void SendSerialCommandList() => _hardwareRamp.SendSerialCommandList();
     public void ResetSerialCommands() => _hardwareRamp.ResetSerialCommands();
     public Task<string> ReadSerialCommandAsync() => _hardwareRamp.ReadSerialCommandAsync();
+    
+    public void ToggleSweepingMode()
+    {
+        _rampController.IsSweeping = !_rampController.IsSweeping;
+        Debug.Log($"Sweeping mode is: {_rampController.IsSweeping}");
+    }
 
     public void RandomBallDrop(int randomRotation, int randomElevation) 
     {

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -129,22 +129,11 @@ public class HardwareRamp : RampController, ISerialController
             { 1, _model.RampSettings.RotationLimitMax }
         };
 
-        // if (_model.IsRampMoving)
-        // {
-        //     _model.ToggleSweepingMode();
-        //     Debug.Log($"Ramp rotation is {Rotation}");
-        //     // _model.SetRampMoving(false);
-        // }
-        // else
-        // {
-        //     _model.ToggleSweepingMode();
-        //     Rotation = rotationLimits[direction];
-        // }
         Rotation = rotationLimits[direction];
-        // Sweep direction: 1 for clockwise, 0 for counterclockwise
+        
         AddSerialCommandToList($"rs{direction}");
         _model.SendSerialCommandList();
-        Debug.Log($"Hardware rotation sweep: {direction}");
+        
         SendChangeEvent();
     }
 

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -112,6 +112,31 @@ public class HardwareRamp : RampController, ISerialController
         SendChangeEvent();
     }
 
+    public void RotationSweep(int direction)
+    {
+        var rotationLimits = new Dictionary<int, float>
+        {
+            { 0, _model.RampSettings.RotationLimitMin },
+            { 1, _model.RampSettings.RotationLimitMax }
+        };
+
+        if (_model.IsRampMoving)
+        {
+            Rotation = _model.CurrentRotationAngle;
+            Debug.Log($"Ramp rotation is {Rotation}");
+            _model.SetRampMoving(false);
+        }
+        else
+        {
+            Rotation = rotationLimits[direction];
+        }
+        // Sweep direction: 1 for clockwise, 0 for counterclockwise
+        AddSerialCommandToList($"rs{direction}");
+        _model.SendSerialCommandList();
+        Debug.Log($"Hardware rotation sweep: {direction}");
+        SendChangeEvent();
+    }
+
     public void ElevateBy(float elevation)
     {
         // Store the previous elevation
@@ -157,6 +182,15 @@ public class HardwareRamp : RampController, ISerialController
         AddSerialCommandToList($"ea{Elevation.ToString("0")}");
         _model.SendSerialCommandList();
         // Debug.Log($"Hardware elevate to: {Elevation}");
+        SendChangeEvent();
+    }
+
+    public void ElevateSweep(int direction)
+    {
+        // Sweep direction: 1 for up, 0 for down
+        AddSerialCommandToList($"es{direction}");
+        _model.SendSerialCommandList();
+        // Debug.Log($"Hardware elevation sweep: {direction}");
         SendChangeEvent();
     }
 

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -116,6 +116,7 @@ public class HardwareRamp : RampController, ISerialController
 
     public void SetRotation(float degrees)
     {
+        // Same as RotateTo, without sending the serial command
         Rotation = degrees;
         // Debug.Log($"Hardware rotate to: {Rotation}");
         SendChangeEvent();
@@ -185,12 +186,27 @@ public class HardwareRamp : RampController, ISerialController
         SendChangeEvent();
     }
 
+    public void SetElevation(float elevation)
+    {
+        // Same as ElevateTo, without sending the serial command
+        Elevation = elevation;
+        // Debug.Log($"Hardware elevate to: {Elevation}");
+        SendChangeEvent();
+    }
+
     public void ElevateSweep(int direction)
     {
-        // Sweep direction: 1 for up, 0 for down
+        var elevationLimits = new Dictionary<int, float>
+        {
+            { 0, _model.RampSettings.ElevationLimitMin },
+            { 1, _model.RampSettings.ElevationLimitMax }
+        };
+
+        Elevation = elevationLimits[direction];
+
         AddSerialCommandToList($"es{direction}");
         _model.SendSerialCommandList();
-        // Debug.Log($"Hardware elevation sweep: {direction}");
+
         SendChangeEvent();
     }
 

--- a/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/HardwareRamp.cs
@@ -37,6 +37,7 @@ public class HardwareRamp : RampController, ISerialController
 
     public bool IsBarOpen { get; private set;}
     public bool IsMoving { get; set; }
+    public bool IsSweeping { get; set; }
 
     public bool SerialEnabled { get; private set; }    
 
@@ -61,6 +62,7 @@ public class HardwareRamp : RampController, ISerialController
         Elevation = _model.RampSettings.ElevationOrigin;
         IsBarOpen = false; // Initialize the bar state as closed
         IsMoving = false;
+        IsSweeping = false;
         _serialCommand = "";
         _serialCommandsList = new List<string>();
     }
@@ -89,7 +91,7 @@ public class HardwareRamp : RampController, ISerialController
         }        
         AddSerialCommandToList($"rr{degrees.ToString("0")}");
         _model.SendSerialCommandList();
-        // Debug.Log($"Hardware rotate by: {degrees}");
+        Debug.Log($"Hardware rotate by: {degrees}");
         SendChangeEvent();
     }
 
@@ -112,6 +114,13 @@ public class HardwareRamp : RampController, ISerialController
         SendChangeEvent();
     }
 
+    public void SetRotation(float degrees)
+    {
+        Rotation = degrees;
+        // Debug.Log($"Hardware rotate to: {Rotation}");
+        SendChangeEvent();
+    }
+
     public void RotationSweep(int direction)
     {
         var rotationLimits = new Dictionary<int, float>
@@ -120,16 +129,18 @@ public class HardwareRamp : RampController, ISerialController
             { 1, _model.RampSettings.RotationLimitMax }
         };
 
-        if (_model.IsRampMoving)
-        {
-            Rotation = _model.CurrentRotationAngle;
-            Debug.Log($"Ramp rotation is {Rotation}");
-            _model.SetRampMoving(false);
-        }
-        else
-        {
-            Rotation = rotationLimits[direction];
-        }
+        // if (_model.IsRampMoving)
+        // {
+        //     _model.ToggleSweepingMode();
+        //     Debug.Log($"Ramp rotation is {Rotation}");
+        //     // _model.SetRampMoving(false);
+        // }
+        // else
+        // {
+        //     _model.ToggleSweepingMode();
+        //     Rotation = rotationLimits[direction];
+        // }
+        Rotation = rotationLimits[direction];
         // Sweep direction: 1 for clockwise, 0 for counterclockwise
         AddSerialCommandToList($"rs{direction}");
         _model.SendSerialCommandList();

--- a/Boccia-Unity/Assets/Boccia/Model/RampController.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/RampController.cs
@@ -8,9 +8,11 @@ public interface RampController
     public float Elevation { get; }
     public bool IsBarOpen { get; }
     public bool IsMoving { get; set; }
+    public bool IsSweeping { get; set; }
 
     public void RotateBy(float degrees);
     public void RotateTo(float degrees);
+    public void SetRotation(float degrees);
     public void ElevateBy(float elevation);
     public void ElevateTo(float elevation);
     public void ResetRampPosition();

--- a/Boccia-Unity/Assets/Boccia/Model/RampController.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/RampController.cs
@@ -15,6 +15,7 @@ public interface RampController
     public void SetRotation(float degrees);
     public void ElevateBy(float elevation);
     public void ElevateTo(float elevation);
+    public void SetElevation(float elevation);
     public void ResetRampPosition();
     public void DropBall();
     public void ResetBar();

--- a/Boccia-Unity/Assets/Boccia/Model/SimulatedRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/SimulatedRamp.cs
@@ -61,8 +61,9 @@ public class SimulatedRamp : RampController
 
     public void SetRotation(float degrees)
     {
-        // Set rotation without clamping
+        // Same as RotateTo, for consistency with the interface
         Rotation = degrees;
+        SendChangeEvent();
     }
 
     public void ElevateBy(float elevation)
@@ -78,6 +79,13 @@ public class SimulatedRamp : RampController
         // Absolute elevation
         Elevation = elevation;
         // Debug.Log($"Simulated elevation to: {Elevation}");
+        SendChangeEvent();
+    }
+
+    public void SetElevation(float elevation)
+    {
+        // Same as ElevateTo, for consistency with the interface
+        Elevation = elevation;
         SendChangeEvent();
     }
 

--- a/Boccia-Unity/Assets/Boccia/Model/SimulatedRamp.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/SimulatedRamp.cs
@@ -30,6 +30,7 @@ public class SimulatedRamp : RampController
 
     public bool IsBarOpen { get; private set;}
     public bool IsMoving { get; set; }
+    public bool IsSweeping { get; set; }
 
     public SimulatedRamp()
     {
@@ -39,6 +40,7 @@ public class SimulatedRamp : RampController
         Elevation = _model.RampSettings.ElevationOrigin;
         IsBarOpen = false; // Initialize the bar state as closed
         IsMoving = false;
+        IsSweeping = false;
     }
 
     public void RotateBy(float degrees)
@@ -55,6 +57,12 @@ public class SimulatedRamp : RampController
         Rotation = degrees;
         //Debug.Log($"Simulated rotation to: {Rotation}");
         SendChangeEvent();
+    }
+
+    public void SetRotation(float degrees)
+    {
+        // Set rotation without clamping
+        Rotation = degrees;
     }
 
     public void ElevateBy(float elevation)

--- a/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
@@ -164,21 +164,21 @@ public class RampPresenter : MonoBehaviour
             // If the rotation visualization started do to a sweeping movement
             if (RotationDueToSweeping)
             {
-                Debug.Log("Sweeping movement in progress");
+                // Normalize the rotation angle to be between -180 and 180 deg
+                float normalizedStopAngle = rotationShaft.transform.localEulerAngles.y; 
+                normalizedStopAngle = (normalizedStopAngle > 180) ? normalizedStopAngle - 360 : normalizedStopAngle;
+
                 // - Check if the Sweeping flag is down, if so stop the sweeping movement.
                 if (_model.IsSweeping == false)
-                {
-                    Debug.Log("Sweeping movement stopped");
-                    _model.SetRotation(rotationShaft.transform.localEulerAngles.y);
-
-                    // _model.CurrentRotationAngle = rotationShaft.transform.localEulerAngles.y;
+                {                    
+                    // Set rotation without sending serial command
+                    _model.SetRotation(normalizedStopAngle); 
                     yield break;
                 }
 
                 // - Check if the target has been reached, if so set target to oposite direction to keep sweeping
-                if (Mathf.Abs(_model.CurrentRotationAngle - targetAngle) < 1f)
+                if (Mathf.Abs(normalizedStopAngle - targetAngle) < 1f)
                 {
-                    Debug.Log("Sweeping movement reached limit");
                     _model.RotationSweep(ToggleRotationWhileSweeping(targetAngle));
                     yield break;
                 }   
@@ -263,6 +263,5 @@ public class RampPresenter : MonoBehaviour
             _lastPlayMode = currentPlayMode;
         }
     }
-
 }
 

--- a/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/Ramp/RampPresenter.cs
@@ -150,11 +150,19 @@ public class RampPresenter : MonoBehaviour
             float t = currentAngle / deltaAngle;
             rotationShaft.transform.localRotation = Quaternion.Slerp(startQuaternion, endQuaternion, t);
             
+            // Update the current rotation angle in the model if it has changed significantly
+            float newRotationAngle = rotationShaft.transform.localEulerAngles.y;
+            if (Mathf.Abs(newRotationAngle - _model.CurrentRotationAngle) > 1f) // Adjust the threshold as needed
+            {
+                _model.CurrentRotationAngle = newRotationAngle;
+            }
+            
             yield return null;
         }
 
         // Ensure the final rotation matches exactly
         rotationShaft.transform.localRotation = endQuaternion;
+        _model.CurrentRotationAngle = rotationShaft.transform.localEulerAngles.y;
     }
 
     private IEnumerator ElevationVisualization()

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -47,7 +47,8 @@ public class PlayScreenPresenter : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        
+        HandleRotationSweep();
+        HandleElevationSweep();
     }
 
     void OnEnable()
@@ -104,6 +105,43 @@ public class PlayScreenPresenter : MonoBehaviour
                 _checkSerialCoroutine = null;
             }
         }
+    }
+
+    private void HandleRotationSweep()
+    {
+        var keyActions = new Dictionary<KeyCode, int>
+        {
+            { KeyCode.LeftArrow, 0 },
+            { KeyCode.RightArrow, 1 }
+        };
+
+        foreach (var keyAction in keyActions)
+        {
+            if (Input.GetKeyDown(keyAction.Key) || Input.GetKeyUp(keyAction.Key))
+            {
+                _model.RotationSweep(keyAction.Value);
+                Debug.Log("Rotation sweep: " + keyAction.Value);
+            }
+        }
+    }
+
+    private void HandleElevationSweep()
+    {
+        var keyActions = new Dictionary<KeyCode, int>
+        {
+            { KeyCode.UpArrow, 0 },
+            { KeyCode.DownArrow, 1 }
+        };
+
+        foreach (var keyAction in keyActions)
+        {
+            if (Input.GetKeyDown(keyAction.Key) || Input.GetKeyUp(keyAction.Key))
+            {
+                _model.ElevationSweep(keyAction.Value);
+                Debug.Log("Elevation sweep: " + keyAction.Value);
+            }
+        }
+
     }
 
     private IEnumerator ReadSerialCommand()

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -38,8 +38,8 @@ public class PlayScreenPresenter : MonoBehaviour
 
     private Dictionary<KeyCode, int> _elevationActions = new()
     {
-        { KeyCode.UpArrow, 0 },
-        { KeyCode.DownArrow, 1 }
+        { KeyCode.DownArrow, 0 },
+        { KeyCode.UpArrow, 1 }
     };
 
     
@@ -127,7 +127,7 @@ public class PlayScreenPresenter : MonoBehaviour
             {
                 _model.ToggleSweepingMode();
                 _model.RotationSweep(keyAction.Value);
-                Debug.Log("Rotation sweep: " + keyAction.Value);
+                // Debug.Log("Rotation sweep: " + keyAction.Value);
             }
         }
     }
@@ -138,8 +138,9 @@ public class PlayScreenPresenter : MonoBehaviour
         {
             if (Input.GetKeyDown(keyAction.Key) || Input.GetKeyUp(keyAction.Key))
             {
+                _model.ToggleSweepingMode();
                 _model.ElevationSweep(keyAction.Value);
-                Debug.Log("Elevation sweep: " + keyAction.Value);
+                // Debug.Log("Elevation sweep: " + keyAction.Value);
             }
         }
 

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -20,15 +20,27 @@ public class PlayScreenPresenter : MonoBehaviour
     [Header("Serial Connection")]
     public GameObject serialStatusIndicator;
 
-    private bool connectionStatus;
+    private bool _connectionStatus;
     private Coroutine _checkSerialCoroutine;
     private Coroutine _readSerialCommandCoroutine;
-    private float _waitTime = 6f;
+    private readonly float _waitTime = 6f;
 
     private BocciaModel _model;
 
     private int _randomRotation;
     private int _randomElevation;
+
+    private Dictionary<KeyCode, int> _rotationActions = new()
+    {
+        { KeyCode.LeftArrow, 0 },
+        { KeyCode.RightArrow, 1 }
+    };
+
+    private Dictionary<KeyCode, int> _elevationActions = new()
+    {
+        { KeyCode.UpArrow, 0 },
+        { KeyCode.DownArrow, 1 }
+    };
 
     
 
@@ -109,16 +121,11 @@ public class PlayScreenPresenter : MonoBehaviour
 
     private void HandleRotationSweep()
     {
-        var keyActions = new Dictionary<KeyCode, int>
-        {
-            { KeyCode.LeftArrow, 0 },
-            { KeyCode.RightArrow, 1 }
-        };
-
-        foreach (var keyAction in keyActions)
+        foreach (var keyAction in _rotationActions)
         {
             if (Input.GetKeyDown(keyAction.Key) || Input.GetKeyUp(keyAction.Key))
             {
+                _model.ToggleSweepingMode();
                 _model.RotationSweep(keyAction.Value);
                 Debug.Log("Rotation sweep: " + keyAction.Value);
             }
@@ -127,13 +134,7 @@ public class PlayScreenPresenter : MonoBehaviour
 
     private void HandleElevationSweep()
     {
-        var keyActions = new Dictionary<KeyCode, int>
-        {
-            { KeyCode.UpArrow, 0 },
-            { KeyCode.DownArrow, 1 }
-        };
-
-        foreach (var keyAction in keyActions)
+        foreach (var keyAction in _elevationActions)
         {
             if (Input.GetKeyDown(keyAction.Key) || Input.GetKeyUp(keyAction.Key))
             {
@@ -189,8 +190,8 @@ public class PlayScreenPresenter : MonoBehaviour
     private IEnumerator CheckSerialPortConnection()
     {
         // Initialize indicator
-        connectionStatus = IsPortConnected(_model.HardwareSettings.COMPort);
-        IndicateSerialStatus(connectionStatus);
+        _connectionStatus = IsPortConnected(_model.HardwareSettings.COMPort);
+        IndicateSerialStatus(_connectionStatus);
 
         // Check every 6 seconds while the serial port is connected
         while (IsPortConnected(_model.HardwareSettings.COMPort))


### PR DESCRIPTION
# Description 
Implemented sweeping mode for Play Boccia! mode

# Implementation
When in the play screen, the ramp can be controlled using the arrow keys on the keyboard. The workflow is as follows:
- `PlayScreenPresenter` is listening to `keyDown` and `keyUp` events to toggle sweeping mode
- According to the key pressed, rotation or elevation is set to the min or max limit. This starts the `RampPresenter` visualization
- In `RampPresenter` there is a flag to determine if the movement animation started due to a sweeping motion, if it did, the `IsSweeping` flag is checked inside the while loop that controls the movement animation. 
- If the limit is reached, and the key is still pressed, the sweeping direction is changed. This behaviour is set to match the current firmware
- If the key is released, the current position (i.e., rotation or elevation) is stored in the model using the `SetRotation` or `SetElevation`. These methods are the same as `RotateTo` or `ElevateTo` without sending a serial command (if connected to the Arduino).

# Testing
- Go to Play Boccia mode and use the arrow keys to control the ramp.

# Notes
Unexpected behaviors that need to be fixed later are:
- Fan should be hidden during motion, and fineFan should be displayed once the sweeping motion stops
- A bug can happen if you start a sweeping rotation and transition to a sweeping elevation without releasing the rotation button or viceversa.