### PR TITLE
Connect button SPOs to OnSelectedEvents

### DIFF
--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -4,6 +4,9 @@ using System.IO.Ports;
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
+using UnityEngine.EventSystems;
+using BCIEssentials.StimulusObjects;
+using BCIEssentials.StimulusEffects;
 
 public class PlayScreenPresenter : MonoBehaviour
 {
@@ -36,12 +39,27 @@ public class PlayScreenPresenter : MonoBehaviour
     void Start()
     {
         _model = BocciaModel.Instance;
-
-        // connect buttons to model
-        resetRampButton.onClick.AddListener(ResetRamp);
-        randomBallButton.onClick.AddListener(SetRandomBallDropPosition);
-
         _model.NavigationChanged += NavigationChanged;
+
+        // Add listeners to Play buttons
+        addListenersToPlayButtons();
+    }
+
+    private void addListenersToPlayButtons()
+    {
+        addListenerToButton(resetRampButton, ResetRamp);
+        addListenerToButton(randomBallButton, SetRandomBallDropPosition);
+    }
+
+    private void addListenerToButton(Button button, UnityEngine.Events.UnityAction action)
+    {
+        button.onClick.AddListener(action);
+        SPO buttonSPO = button.GetComponent<SPO>();
+        if (buttonSPO != null)
+        {
+            buttonSPO.OnSelectedEvent.AddListener(() => button.GetComponent<SPO>().StopStimulus());
+            buttonSPO.OnSelectedEvent.AddListener(() => action());
+        }
     }
 
     // Update is called once per frame

--- a/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
@@ -2,6 +2,9 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.EventSystems;
+using BCIEssentials.StimulusObjects;
+using BCIEssentials.StimulusEffects;
 
 
 // This is an example UI presenter.  This could be broken into several smaller scripts
@@ -40,30 +43,48 @@ public class VirtualPlayPresenter : MonoBehaviour
         // Do not include the camera toggle button
         virtualPlayButtons = new List<Button>()
         {
-            rotateLeftButton,
-            rotateRightButton,
-            moveUpButton,
-            moveDownButton,
             resetRampButton,
             resetBallButton,
-            dropBallButton,
             colorButton,
             randomJackButton,
         };
 
-        // connect buttons to model
+        // Add listeners to Virtual Play buttons
+        addListenersToVirtualPlayButtons();
+
+        // Connect the camera toggle button
+        toggleCameraButton.onClick.AddListener(ToggleCamera);
+
+        // Connect testing buttons
+        connectTestingButtons();
+    }
+
+    private void addListenersToVirtualPlayButtons()
+    {
+        addListenerToButton(resetRampButton, ResetRamp);
+        addListenerToButton(resetBallButton, model.ResetVirtualBalls);
+        addListenerToButton(colorButton, model.RandomBallColor);
+        addListenerToButton(randomJackButton, model.RandomJackBall);
+    }
+
+    private void addListenerToButton(Button button, UnityEngine.Events.UnityAction action)
+    {
+        button.onClick.AddListener(action);
+        SPO buttonSPO = button.GetComponent<SPO>();
+        if (buttonSPO != null)
+        {
+            buttonSPO.OnSelectedEvent.AddListener(() => button.GetComponent<SPO>().StopStimulus());
+            buttonSPO.OnSelectedEvent.AddListener(() => action());
+        }
+    }
+
+    private void connectTestingButtons()
+    {
         rotateLeftButton.onClick.AddListener(RotateLeft);
         rotateRightButton.onClick.AddListener(RotateRight);
         moveUpButton.onClick.AddListener(MoveUp);
         moveDownButton.onClick.AddListener(MoveDown);
-        resetRampButton.onClick.AddListener(ResetRamp);
-        resetBallButton.onClick.AddListener(model.ResetVirtualBalls);
         dropBallButton.onClick.AddListener(model.DropBall);
-        colorButton.onClick.AddListener(model.RandomBallColor);
-        randomJackButton.onClick.AddListener(model.RandomJackBall);
-
-        // Connect the camera toggle button
-        toggleCameraButton.onClick.AddListener(ToggleCamera);
     }
 
 

--- a/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
@@ -50,24 +50,24 @@ public class VirtualPlayPresenter : MonoBehaviour
         };
 
         // Add listeners to Virtual Play buttons
-        addListenersToVirtualPlayButtons();
+        AddListenersToVirtualPlayButtons();
 
         // Connect the camera toggle button
         toggleCameraButton.onClick.AddListener(ToggleCamera);
 
         // Connect testing buttons
-        connectTestingButtons();
+        ConnectTestingButtons();
     }
 
-    private void addListenersToVirtualPlayButtons()
+    private void AddListenersToVirtualPlayButtons()
     {
-        addListenerToButton(resetRampButton, ResetRamp);
-        addListenerToButton(resetBallButton, model.ResetVirtualBalls);
-        addListenerToButton(colorButton, model.RandomBallColor);
-        addListenerToButton(randomJackButton, model.RandomJackBall);
+        AddListenerToButton(resetRampButton, ResetRamp);
+        AddListenerToButton(resetBallButton, model.ResetVirtualBalls);
+        AddListenerToButton(colorButton, model.RandomBallColor);
+        AddListenerToButton(randomJackButton, model.RandomJackBall);
     }
 
-    private void addListenerToButton(Button button, UnityEngine.Events.UnityAction action)
+    private void AddListenerToButton(Button button, UnityEngine.Events.UnityAction action)
     {
         button.onClick.AddListener(action);
         SPO buttonSPO = button.GetComponent<SPO>();
@@ -78,7 +78,7 @@ public class VirtualPlayPresenter : MonoBehaviour
         }
     }
 
-    private void connectTestingButtons()
+    private void ConnectTestingButtons()
     {
         rotateLeftButton.onClick.AddListener(RotateLeft);
         rotateRightButton.onClick.AddListener(RotateRight);


### PR DESCRIPTION
This will close [Issue 138](https://github.com/kirtonBCIlab/boccia-bci/issues/138).

The SPOs of the non-fan buttons in the Virtual Play and Play screens needed to be connected to OnSelectedEvents to actually call the methods when selected with BCI.

### Changes

1. Added methods in `VirtualPlayPresenter` and `PlayScreenPresenter` to connect the button's SPO OnSelectedEvent to each button's method.
2. I also refactored the code a little to use one method (`addListenerToButton()`) to connect both the `OnClick` and `OnSelectedEvent` to the button's method.

### Testing

1. Edit the `CoarseFanSettings` to have 2 columns and 2 rows. This way, the fan segments' SPO Object IDs will only range from 0-4. 
2. Overwrite the `ObjectID` of the Virtual Play buttons (BallColorButton, RandomJackButton, ResetRampButton, and ResetBallsButton) to numbers from 5-9 so all buttons and fan segments can now be selected with the number keys.
3. Start the stimulus in the Virtual Play scene. Select one of the buttons while the stimulus is running using a number key. When the stimulus is complete, you should see that the system actually performs that action now.
4. You can similarly test the buttons in Play by overwriting their ObjectIDs to numbers from 5-9. 