### PR TITLE
Fix the bug preventing multiple BCI trainings

### DIFF
--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -488,6 +488,7 @@ public class BocciaModel : Singleton<BocciaModel>
 
     public void TrainingStarted()
     {
+        BciTrained = false; // Make sure the training state is false
         IsTraining = true;
         SendBciChangeEvent();
     }

--- a/Boccia-Unity/Assets/Boccia/UI/TrainingPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/TrainingPresenter.cs
@@ -36,6 +36,9 @@ public class TrainingPresenter : MonoBehaviour
             _model.WasChanged += ModelChanged;
             _model.BciChanged += BciChanged;
         }
+
+        // Set the instruction text
+        instructionText.GetComponent<TextMeshProUGUI>().text = "Press T to start training.";
     }
 
 


### PR DESCRIPTION
This will close [Issue 132](https://github.com/kirtonBCIlab/boccia-bci/issues/132)

### Issue Description
If you previously completed Training, and then re-entered the training screen at some point and began another training, the game would exit back to the Play Menu without completing training. This was happening due to a flag not being reset.

### Changes

1. `TrainingStarted()` in the model now makes sure `BciTrained` is set to false. So, when `TrainingPresenter` calls `model.BciTrained()`, the `BciTrained` flag will be reset, and additional trainings can be completed properly.
2. I also added logic to `OnEnable()` in `TrainingPresenter()` to make sure the instruction text is "Press T to start training" when entering the Training screen. This means that if a training was previously completed, the "Training complete" text will be replaced to clarify to the user that another training can be started.

### Testing

1. Complete one training. After completing, the game will navigate back the Play Menu.
2. Navigate into the Training Screen again and begin another training. You should now see that the second training now completes without problems.