### PR TITLE
144 export fan settings to json file

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanInteractions.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanInteractions.cs
@@ -15,6 +15,8 @@ public class FanInteractions : MonoBehaviour, IPointerClickHandler
     private FanSettings _fanSettings;
 
     private BocciaModel _model;
+
+    private int _segmentID;
     
     private void Start()
     {
@@ -37,7 +39,7 @@ public class FanInteractions : MonoBehaviour, IPointerClickHandler
         int segmentID = 0;
         foreach (Transform child in transform)
         {
-            // Change layer to the interacaable layer
+            // Change layer to the interacable layer
             child.gameObject.layer = gameObject.layer;
 
             // Add a collider to make segment clickable
@@ -52,7 +54,7 @@ public class FanInteractions : MonoBehaviour, IPointerClickHandler
             // Add SPO component to make segment selectable with BCI
             child.tag = "BCI";
             SPO spo = child.AddComponent<SPO>();
-            spo.ObjectID = segmentID;
+            spo.ObjectID = -100;
             spo.Selectable = true;
 
             spo.StartStimulusEvent.AddListener(() => child.GetComponent<FanSegmentColorFlashEffect>().SetOn());
@@ -66,6 +68,8 @@ public class FanInteractions : MonoBehaviour, IPointerClickHandler
             BCITargetAnimations bciTargetAnimations = child.gameObject.AddComponent<BCITargetAnimations>();
             bciTargetAnimations.bocciaAnimation = _model.P300Settings.Train.TargetAnimation;
 
+            FanSegmentIdentifier segmentIdentifier = child.AddComponent<FanSegmentIdentifier>();
+            segmentIdentifier.SegmentID = segmentID;
             segmentID++;
         }
     }
@@ -76,8 +80,8 @@ public class FanInteractions : MonoBehaviour, IPointerClickHandler
         switch (segmentName)
         {
             case "FanSegment":
-                SPO spo = segment.GetComponent<SPO>();
-                int segmentID = spo.ObjectID;
+                FanSegmentIdentifier identifier = segment.GetComponent<FanSegmentIdentifier>();
+                int segmentID = identifier.SegmentID;
                 OnFanSegmentClick(segmentID);
 
                 // Handle which fan to draw next based on the positioning mode

--- a/Boccia-Unity/Assets/Boccia/BCI/FanNamespace.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanNamespace.cs
@@ -15,7 +15,7 @@ namespace FanNamespace
         CenterToRails,
         CenterToBase,
         CenterNorth,
-        GameOptionsMenu
+        GameOptionsMenu,
     }
 
     [CreateAssetMenu(fileName = "FanSettings", menuName = "Fan/FanSettings")]

--- a/Boccia-Unity/Assets/Boccia/BCI/FanSegmentIdentifier.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanSegmentIdentifier.cs
@@ -1,0 +1,7 @@
+using UnityEngine;
+
+
+public class FanSegmentIdentifier : MonoBehaviour
+{
+    public int SegmentID { get; set; }
+}

--- a/Boccia-Unity/Assets/Boccia/BCI/FanSegmentIdentifier.cs.meta
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanSegmentIdentifier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3795aae047e0aac43b90bdf6d7162d3e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boccia-Unity/Assets/Boccia/BCI/SettingsExporter.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/SettingsExporter.cs
@@ -1,0 +1,48 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using FanNamespace;
+using System.IO;
+
+public class SettingsExporter : MonoBehaviour
+{
+    private BocciaModel _model;
+
+    [Header("Fan settings")]
+    [SerializeField]
+    private FanSettings _fineFanSettings;
+
+    [SerializeField]
+    private FanSettings _coarseFanSettings;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        _model = BocciaModel.Instance;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.S))
+        {
+            ExportSettings();
+        }
+        
+    }
+
+    private void ExportSettings()
+    {
+        string jsonCoarseFan = JsonUtility.ToJson(_coarseFanSettings, true);
+        string jsonFineFan = JsonUtility.ToJson(_fineFanSettings, true);
+        string jsonP300Settings = JsonUtility.ToJson(_model.P300Settings, true);
+
+        string json = "{\"coarseFanSettings\": " + jsonCoarseFan + ", \"fineFanSettings\": " + jsonFineFan + ", \"P300Settings\": " + jsonP300Settings + "}";
+
+        string path = Path.Combine(Application.persistentDataPath, "TrialSettings.json");
+
+        File.WriteAllText(path, json);
+
+        Debug.Log($"Exported coarse fan settings to {path}");
+    }
+}

--- a/Boccia-Unity/Assets/Boccia/BCI/SettingsExporter.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/SettingsExporter.cs
@@ -56,7 +56,7 @@ public class SettingsExporter : MonoBehaviour
                     ", \"fineFanSettings\": " + jsonFineFan + 
                     ", \"P300Settings\": " + jsonP300Settings + "}";
 
-        string filename = $"TrialSettings_{_trialNumber}.json";
+        string filename = $"{currentDateTime}_Trial_{_trialNumber}_Settings.json";
         string path = Path.Combine(_settingsDir, filename);
 
         File.WriteAllText(path, json);

--- a/Boccia-Unity/Assets/Boccia/BCI/SettingsExporter.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/SettingsExporter.cs
@@ -40,19 +40,21 @@ public class SettingsExporter : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if (Input.GetKeyDown(KeyCode.S))
+        if (Input.GetKeyDown(KeyCode.J))
         {
+            _trialNumber++;
             ExportSettings();
         }
     }
 
     private void ExportSettings()
     {
+        string currentDateTime = System.DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss");
         string jsonCoarseFan = JsonUtility.ToJson(_coarseFanSettings, true);
         string jsonFineFan = JsonUtility.ToJson(_fineFanSettings, true);
         string jsonP300Settings = JsonUtility.ToJson(_model.P300Settings, true);
 
-        string json = "{\"coarseFanSettings\": " + jsonCoarseFan + ", \"fineFanSettings\": " + jsonFineFan + ", \"P300Settings\": " + jsonP300Settings + "}";
+        string json = "{\"trialNumber\": " + _trialNumber + ", \"currentDateTime\": " + currentDateTime + ", \"coarseFanSettings\": " + jsonCoarseFan + ", \"fineFanSettings\": " + jsonFineFan + ", \"P300Settings\": " + jsonP300Settings + "}";
 
         string filename = $"TrialSettings_{_trialNumber}.json";
         string path = Path.Combine(_settingsDir, filename);

--- a/Boccia-Unity/Assets/Boccia/BCI/SettingsExporter.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/SettingsExporter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -26,12 +27,7 @@ public class SettingsExporter : MonoBehaviour
         _model = BocciaModel.Instance;
 
         // Set directory for saving trial settings
-        _settingsDir = @"C:\Users\Daniella\Documents\BocciaTrials";
-
-        if (!Directory.Exists(_settingsDir))
-        {
-            Directory.CreateDirectory(_settingsDir);
-        }
+        _settingsDir = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 
         // Initialize trial number at 0
         _trialNumber = 0;
@@ -54,13 +50,17 @@ public class SettingsExporter : MonoBehaviour
         string jsonFineFan = JsonUtility.ToJson(_fineFanSettings, true);
         string jsonP300Settings = JsonUtility.ToJson(_model.P300Settings, true);
 
-        string json = "{\"trialNumber\": " + _trialNumber + ", \"currentDateTime\": " + currentDateTime + ", \"coarseFanSettings\": " + jsonCoarseFan + ", \"fineFanSettings\": " + jsonFineFan + ", \"P300Settings\": " + jsonP300Settings + "}";
+        string json = "{\"trialNumber\": " + _trialNumber + 
+                    ", \"currentDateTime\": \"" + currentDateTime + "\"" +
+                    ", \"coarseFanSettings\": " + jsonCoarseFan + 
+                    ", \"fineFanSettings\": " + jsonFineFan + 
+                    ", \"P300Settings\": " + jsonP300Settings + "}";
 
         string filename = $"TrialSettings_{_trialNumber}.json";
         string path = Path.Combine(_settingsDir, filename);
 
         File.WriteAllText(path, json);
 
-        Debug.Log($"Exported trial {_trialNumber} settings to {path}");
+        Debug.Log($"Exported Trial {_trialNumber} settings to {path}");
     }
 }

--- a/Boccia-Unity/Assets/Boccia/BCI/SettingsExporter.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/SettingsExporter.cs
@@ -8,6 +8,11 @@ public class SettingsExporter : MonoBehaviour
 {
     private BocciaModel _model;
 
+    [Header("Trial Settings")]
+    [SerializeField]
+    private int _trialNumber;
+    private string _settingsDir;
+
     [Header("Fan settings")]
     [SerializeField]
     private FanSettings _fineFanSettings;
@@ -19,6 +24,17 @@ public class SettingsExporter : MonoBehaviour
     void Start()
     {
         _model = BocciaModel.Instance;
+
+        // Set directory for saving trial settings
+        _settingsDir = @"C:\Users\Daniella\Documents\BocciaTrials";
+
+        if (!Directory.Exists(_settingsDir))
+        {
+            Directory.CreateDirectory(_settingsDir);
+        }
+
+        // Initialize trial number at 0
+        _trialNumber = 0;
     }
 
     // Update is called once per frame
@@ -28,7 +44,6 @@ public class SettingsExporter : MonoBehaviour
         {
             ExportSettings();
         }
-        
     }
 
     private void ExportSettings()
@@ -39,10 +54,11 @@ public class SettingsExporter : MonoBehaviour
 
         string json = "{\"coarseFanSettings\": " + jsonCoarseFan + ", \"fineFanSettings\": " + jsonFineFan + ", \"P300Settings\": " + jsonP300Settings + "}";
 
-        string path = Path.Combine(Application.persistentDataPath, "TrialSettings.json");
+        string filename = $"TrialSettings_{_trialNumber}.json";
+        string path = Path.Combine(_settingsDir, filename);
 
         File.WriteAllText(path, json);
 
-        Debug.Log($"Exported coarse fan settings to {path}");
+        Debug.Log($"Exported trial {_trialNumber} settings to {path}");
     }
 }

--- a/Boccia-Unity/Assets/Boccia/BCI/SettingsExporter.cs.meta
+++ b/Boccia-Unity/Assets/Boccia/BCI/SettingsExporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6918da7c742f07348b0b07714ae8c48f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
@@ -1608,6 +1608,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7764173004061172451}
   - component: {fileID: 3576948454555312335}
+  - component: {fileID: 8716667809871874162}
   m_Layer: 6
   m_Name: VirtualPlayScreen
   m_TagString: Untagged
@@ -1654,6 +1655,20 @@ MonoBehaviour:
   randomJackButton: {fileID: 0}
   toggleCameraButton: {fileID: 22244603314456237}
   VirtualPlayCamera: {fileID: 0}
+--- !u!114 &8716667809871874162
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4818931384772691849}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6918da7c742f07348b0b07714ae8c48f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _fineFanSettings: {fileID: 11400000, guid: fa646aefe576f30429b0ff7334216751, type: 2}
+  _coarseFanSettings: {fileID: 11400000, guid: 9bf211a5d6524d04a80756a708287313, type: 2}
 --- !u!1 &4999685241904479374
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
This will close [Issue 144](https://github.com/kirtonBCIlab/boccia-bci/issues/144).

### Description
This is for a sub-branch from `2502-fan-segment-testing`.

To facilitate testing the fan segment size, spacing, and other settings, add functionality to save the fan settings and P300 settings to a `.json` file.

### Changes

1. Created a `SettingsExporter` script and attached it to the `VirtualPlayScreen` GameObject.
2. When `J` is pressed in Virtual Play, the current `FineFanSettings`, `CoarseFanSettings`, and `P300Settings` will be exported to a JSON file.
3. Added a `_trialNumber` variable as a counter to keep track of the settings for multiple trials. It is incremented each time `J` is pressed.
4. The file name includes the current date and time, and the trial number. The date and time is included to avoid overwriting the files for same-numbered trials (since Trial Number is initialized at 0 on Start).

### Testing

1. Adjust any `FineFanSettings`, `CoarseFanSettings`, or `P300Settings`. The fan settings can be adjusted in their `ScriptableObjects`. Some of the `FineFanSettings` can be changed in `GameOptions`. The `P300Settings` can be changed in `BCIOptions`.
3. Go to `VirtualPlay` and press `J`.
4. The JSON file should be exported to your Documents folder. Open it and verify that the information matches the settings in Unity.