### PR TITLE
148 Adjust camera location behind ramp

### DIFF
--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/PlayScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/PlayScreen.prefab
@@ -160,7 +160,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 280350794043064211}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -169,7 +169,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -10, y: 159}
+  m_AnchoredPosition: {x: -50, y: 153}
   m_SizeDelta: {x: 240, y: 40}
   m_Pivot: {x: 1, y: 0.5}
 --- !u!222 &4224587864108413799
@@ -248,7 +248,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 120, y: -50}
+  m_AnchoredPosition: {x: 150, y: -130}
   m_SizeDelta: {x: 160, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &491917470012584253
@@ -847,7 +847,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -120, y: -50}
+  m_AnchoredPosition: {x: -150, y: -130}
   m_SizeDelta: {x: 160, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7781101804396931157
@@ -1066,6 +1066,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   resetRampButton: {fileID: 6748951209935578255}
   randomBallButton: {fileID: 0}
+  echoSerialCommands: 1
+  _arduinoIsNeeded: 0
   serialStatusIndicator: {fileID: 280350794043064211}
 --- !u!1 &7973036634516842441
 GameObject:
@@ -1094,7 +1096,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7973036634516842441}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 5}
+  m_LocalPosition: {x: 0, y: 0, z: 139}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1106,7 +1108,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: -9, y: -73.11}
+  m_AnchoredPosition: {x: -9, y: -6}
   m_SizeDelta: {x: 1000, y: 655}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &2012786842390971747

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/PlayScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/PlayScreen.prefab
@@ -248,7 +248,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 150, y: -130}
+  m_AnchoredPosition: {x: 150, y: -100}
   m_SizeDelta: {x: 160, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &491917470012584253
@@ -847,7 +847,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -150, y: -130}
+  m_AnchoredPosition: {x: -150, y: -100}
   m_SizeDelta: {x: 160, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7781101804396931157

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
@@ -349,8 +349,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 24
-  m_fontSizeBase: 24
+  m_fontSize: 22
+  m_fontSizeBase: 22
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 0
@@ -539,7 +539,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2859724575470018110}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 5}
+  m_LocalPosition: {x: 0, y: 0, z: 134}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -557,8 +557,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: -9, y: -116.5}
-  m_SizeDelta: {x: 1101, y: 655}
+  m_AnchoredPosition: {x: -9, y: 228}
+  m_SizeDelta: {x: 1000, y: 655}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &8930885327393908749
 Canvas:
@@ -892,7 +892,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3676631831203774032}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -901,7 +901,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -10, y: 139.00003}
+  m_AnchoredPosition: {x: -65, y: 188}
   m_SizeDelta: {x: 240, y: 44}
   m_Pivot: {x: 1, y: 0}
 --- !u!222 &6300852364910776983
@@ -1078,8 +1078,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 24
-  m_fontSizeBase: 24
+  m_fontSize: 22
+  m_fontSizeBase: 22
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 0
@@ -1212,8 +1212,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 24
-  m_fontSizeBase: 24
+  m_fontSize: 22
+  m_fontSizeBase: 22
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 0
@@ -1283,7 +1283,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4303601759080381808}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1292,8 +1292,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -40, y: -100}
-  m_SizeDelta: {x: 180, y: 60}
+  m_AnchoredPosition: {x: -70, y: -90}
+  m_SizeDelta: {x: 162, y: 54}
   m_Pivot: {x: 1, y: 1}
 --- !u!222 &3931406161124561486
 CanvasRenderer:
@@ -1826,8 +1826,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -40, y: -20}
-  m_SizeDelta: {x: 180, y: 60}
+  m_AnchoredPosition: {x: -70, y: -20}
+  m_SizeDelta: {x: 162, y: 54}
   m_Pivot: {x: 1, y: 1}
 --- !u!222 &6063160319026526717
 CanvasRenderer:
@@ -2224,8 +2224,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 24
-  m_fontSizeBase: 24
+  m_fontSize: 22
+  m_fontSizeBase: 22
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 0
@@ -2550,7 +2550,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7983456653138342303}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -2559,9 +2559,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 120, y: -50}
-  m_SizeDelta: {x: 160, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 240, y: -20}
+  m_SizeDelta: {x: 162, y: 54}
+  m_Pivot: {x: 1, y: 1}
 --- !u!222 &8445251991010630657
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -2894,7 +2894,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8476152213448098857}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -2903,9 +2903,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 120, y: -130}
-  m_SizeDelta: {x: 160, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 240, y: -90}
+  m_SizeDelta: {x: 162, y: 54}
+  m_Pivot: {x: 1, y: 1}
 --- !u!222 &1194208003963516333
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
@@ -892,7 +892,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3676631831203774032}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -901,7 +901,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -65, y: 188}
+  m_AnchoredPosition: {x: -65, y: 200}
   m_SizeDelta: {x: 240, y: 44}
   m_Pivot: {x: 1, y: 0}
 --- !u!222 &6300852364910776983
@@ -1283,7 +1283,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4303601759080381808}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1292,7 +1292,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -70, y: -90}
+  m_AnchoredPosition: {x: -70, y: -76}
   m_SizeDelta: {x: 162, y: 54}
   m_Pivot: {x: 1, y: 1}
 --- !u!222 &3931406161124561486
@@ -1817,7 +1817,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5754980578906772579}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1826,7 +1826,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -70, y: -20}
+  m_AnchoredPosition: {x: -70, y: -6}
   m_SizeDelta: {x: 162, y: 54}
   m_Pivot: {x: 1, y: 1}
 --- !u!222 &6063160319026526717
@@ -2559,7 +2559,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 240, y: -20}
+  m_AnchoredPosition: {x: 240, y: -6}
   m_SizeDelta: {x: 162, y: 54}
   m_Pivot: {x: 1, y: 1}
 --- !u!222 &8445251991010630657
@@ -2903,7 +2903,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 240, y: -90}
+  m_AnchoredPosition: {x: 240, y: -76}
   m_SizeDelta: {x: 162, y: 54}
   m_Pivot: {x: 1, y: 1}
 --- !u!222 &1194208003963516333

--- a/Boccia-Unity/Assets/Boccia/UI/ScreenSwitcher.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/ScreenSwitcher.cs
@@ -9,7 +9,7 @@ public class ScreenSwitcher : MonoBehaviour
 {
     public Camera ScreenCamera;
     public float CameraDistance = 600.0f;
-    public float RampViewCameraDistance = 5.0f; // Custom distance so the camera will view the ramp
+    public float ScreenDistance = 5.0f; // Distance to view screens
     public float CameraSpeed = 5.0f;
 
     private Vector3 targetPosition;
@@ -69,37 +69,37 @@ public class ScreenSwitcher : MonoBehaviour
         switch (model.CurrentScreen)
         {
             case BocciaScreen.PlayMenu:
-                PanCameraToScreen(PlayMenu, RampViewCameraDistance);
+                PanCameraToScreen(PlayMenu, ScreenDistance);
                 break;
                 
             case BocciaScreen.HamburgerMenu:
-                PanCameraToScreen(HamburgerMenuOptions, RampViewCameraDistance);
+                PanCameraToScreen(HamburgerMenuOptions, ScreenDistance);
                 break;
 
             case BocciaScreen.TrainingScreen:
-                PanCameraToScreen(TrainingScreen, RampViewCameraDistance);
+                PanCameraToScreen(TrainingScreen, ScreenDistance);
                 break;
 
             case BocciaScreen.RampSetup:
                 // First show the play menu since ramp setup displays there
-                PanCameraToScreen(PlayMenu, RampViewCameraDistance);
+                PanCameraToScreen(PlayMenu, ScreenDistance);
                 ShowRampSetupMenu(true);
                 break;
 
             case BocciaScreen.Play:
-                PanCameraToScreen(PlayScreen, RampViewCameraDistance);
+                PanCameraToScreen(PlayScreen, ScreenDistance);
                 break;
 
             case BocciaScreen.VirtualPlay:
-                PanCameraToScreen(VirtualPlayScreen, RampViewCameraDistance);
+                PanCameraToScreen(VirtualPlayScreen, ScreenDistance);
                 break;
 
             case BocciaScreen.GameOptions:
-                PanCameraToScreen(GameOptionsMenu, RampViewCameraDistance);
+                PanCameraToScreen(GameOptionsMenu, ScreenDistance);
                 break;
 
             case BocciaScreen.BciOptions:
-                PanCameraToScreen(BciOptionsMenu, RampViewCameraDistance);
+                PanCameraToScreen(BciOptionsMenu, ScreenDistance);
                 break;
             
             // For now just switch back to start menu to show switching works

--- a/Boccia-Unity/Assets/Boccia/UI/ScreenSwitcher.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/ScreenSwitcher.cs
@@ -10,7 +10,8 @@ public class ScreenSwitcher : MonoBehaviour
     public Camera ScreenCamera;
     public float CameraDistance = 600.0f;
     public float ScreenDistance = 5.0f; // Distance to view screens
-    public float RampViewDistance = 3.1f; // Distance to place the camera behind the ramp
+    public float RampViewDistance = 3.3f; // Distance to place the camera behind the ramp
+    public float RampCameraHeight = 2.3f; // Y-position of the camera when looking at the ramp
     public float CameraSpeed = 5.0f;
 
     private Vector3 targetPosition;
@@ -133,6 +134,12 @@ public class ScreenSwitcher : MonoBehaviour
     {
         // Calculate target camera pose based on screen's postion and direction in world space
         targetPosition = screenToShow.transform.position + screenToShow.transform.forward * distance * -1.0f;
+
+        if (IsRampView())
+        {
+            targetPosition.y = RampCameraHeight;
+        }
+
         targetRotation = screenToShow.transform.rotation;
 
         // Spawn two routines to move the camera to the new pose.  Use private members for target
@@ -168,5 +175,10 @@ public class ScreenSwitcher : MonoBehaviour
     private void ShowRampSetupMenu(bool isActive)
     {
         RampSetupMenu.SetActive(isActive);
+    }
+
+    private bool IsRampView()
+    {
+        return (model.CurrentScreen == BocciaScreen.Play || model.CurrentScreen == BocciaScreen.VirtualPlay);
     }
 }

--- a/Boccia-Unity/Assets/Boccia/UI/ScreenSwitcher.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/ScreenSwitcher.cs
@@ -10,6 +10,7 @@ public class ScreenSwitcher : MonoBehaviour
     public Camera ScreenCamera;
     public float CameraDistance = 600.0f;
     public float ScreenDistance = 5.0f; // Distance to view screens
+    public float RampViewDistance = 3.1f; // Distance to place the camera behind the ramp
     public float CameraSpeed = 5.0f;
 
     private Vector3 targetPosition;
@@ -87,11 +88,11 @@ public class ScreenSwitcher : MonoBehaviour
                 break;
 
             case BocciaScreen.Play:
-                PanCameraToScreen(PlayScreen, ScreenDistance);
+                PanCameraToScreen(PlayScreen, RampViewDistance);
                 break;
 
             case BocciaScreen.VirtualPlay:
-                PanCameraToScreen(VirtualPlayScreen, ScreenDistance);
+                PanCameraToScreen(VirtualPlayScreen, RampViewDistance);
                 break;
 
             case BocciaScreen.GameOptions:

--- a/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
+++ b/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
@@ -1551,7 +1551,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ce7290849ae141245a87db13adfc695f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  trainTargetAnimation: 2
+  bocciaAnimation: 0
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
@@ -2137,7 +2137,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ce7290849ae141245a87db13adfc695f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  trainTargetAnimation: 2
+  bocciaAnimation: 0
 --- !u!1001 &1132938592
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2148,7 +2148,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 281971961862754810, guid: 478a387523a05364c8d059c19c67e161, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 149.99998
+      value: 150
       objectReference: {fileID: 0}
     - target: {fileID: 1360815048455865100, guid: 478a387523a05364c8d059c19c67e161, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2533,7 +2533,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ce7290849ae141245a87db13adfc695f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  trainTargetAnimation: 2
+  bocciaAnimation: 0
 --- !u!114 &1281730594 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3214086637462062914, guid: 61bd1dc80c9f06c45b87ea455ac607ff, type: 3}
@@ -3325,6 +3325,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 2146497314}
     m_Modifications:
+    - target: {fileID: 1493494056422143403, guid: 6a619933318bf764aa5fb150788918f3, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -6.0000916
+      objectReference: {fileID: 0}
     - target: {fileID: 2859724575470018110, guid: 6a619933318bf764aa5fb150788918f3, type: 3}
       propertyPath: m_Layer
       value: 6
@@ -3375,11 +3379,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7764173004061172451, guid: 6a619933318bf764aa5fb150788918f3, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.92387956
+      value: 0.9396927
       objectReference: {fileID: 0}
     - target: {fileID: 7764173004061172451, guid: 6a619933318bf764aa5fb150788918f3, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.38268343
+      value: 0.3420201
       objectReference: {fileID: 0}
     - target: {fileID: 7764173004061172451, guid: 6a619933318bf764aa5fb150788918f3, type: 3}
       propertyPath: m_LocalRotation.y
@@ -3391,7 +3395,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7764173004061172451, guid: 6a619933318bf764aa5fb150788918f3, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 45
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 7764173004061172451, guid: 6a619933318bf764aa5fb150788918f3, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
@@ -5375,7 +5379,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ScreenCamera: {fileID: 963194227}
   CameraDistance: 8
-  RampViewCameraDistance: 5
+  ScreenDistance: 5
+  RampViewDistance: 3.1
+  RampCameraHeight: 2.2
   CameraSpeed: 5
   StartMenu: {fileID: 51956294}
   PlayMenu: {fileID: 1883243473}
@@ -5478,11 +5484,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3425727482096386981, guid: 61bd1dc80c9f06c45b87ea455ac607ff, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.92387956
+      value: 0.9396927
       objectReference: {fileID: 0}
     - target: {fileID: 3425727482096386981, guid: 61bd1dc80c9f06c45b87ea455ac607ff, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.38268343
+      value: 0.3420201
       objectReference: {fileID: 0}
     - target: {fileID: 3425727482096386981, guid: 61bd1dc80c9f06c45b87ea455ac607ff, type: 3}
       propertyPath: m_LocalRotation.y
@@ -5494,7 +5500,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3425727482096386981, guid: 61bd1dc80c9f06c45b87ea455ac607ff, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 45
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 3425727482096386981, guid: 61bd1dc80c9f06c45b87ea455ac607ff, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y


### PR DESCRIPTION
This will close [Issue 148](https://github.com/kirtonBCIlab/boccia-bci/issues/148).

**Changes**

Added another variable to screen switcher to use a different camera distance for the Play and Virtual Play screens. 

- I set this variable to have the camera closer to the ramp, while still ensuring the ramp doesn't block any fan segments and keeping the ramp viewing angle the same.
- This eliminates some of the unused space at the lower half of the screens, and it also means the fan appears slightly larger on screen. See the before and after images below.

 I also adjusted the positioning of the remaining UI buttons to fit the new camera distance.