### PR TITLE
Select target element

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanInteractions.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanInteractions.cs
@@ -79,7 +79,8 @@ public class FanInteractions : MonoBehaviour, IPointerClickHandler
         if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift))
         {
             // Store the segment as the target element
-            Debug.Log("Target element is " + segment.name);
+            int segmentID = segment.GetComponent<FanSegmentIdentifier>().SegmentID;
+            _model.SetTargetElement(segmentID);
             return;
         }
 

--- a/Boccia-Unity/Assets/Boccia/BCI/FanInteractions.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanInteractions.cs
@@ -78,9 +78,9 @@ public class FanInteractions : MonoBehaviour, IPointerClickHandler
     {
         if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift))
         {
-            // Store the segment as the target element
-            int segmentID = segment.GetComponent<FanSegmentIdentifier>().SegmentID;
-            _model.SetTargetElement(segmentID);
+            // Store the target segment's SPO
+            SPO segmentSPO = segment.GetComponent<SPO>();
+            _model.SetTargetElement(segmentSPO);
             return;
         }
 

--- a/Boccia-Unity/Assets/Boccia/BCI/FanInteractions.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanInteractions.cs
@@ -76,6 +76,13 @@ public class FanInteractions : MonoBehaviour, IPointerClickHandler
 
     private void OnSegmentClick(Transform segment)
     {
+        if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift))
+        {
+            // Store the segment as the target element
+            Debug.Log("Target element is " + segment.name);
+            return;
+        }
+
         string segmentName = segment.name;
         switch (segmentName)
         {

--- a/Boccia-Unity/Assets/Boccia/BCI/TargetElementLSLStream.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/TargetElementLSLStream.cs
@@ -12,7 +12,7 @@ public class TargetElementLSLStream : MonoBehaviour
     private string StreamType = "Text";
     public string StreamId = "target_element_stream_01";
     private StreamInfo _streamInfo;
-    private string _sample;
+    private string[] _sample;
     private BocciaModel _model;
     // Start is called before the first frame update
     void Start()
@@ -33,8 +33,10 @@ public class TargetElementLSLStream : MonoBehaviour
             return false;
         }
 
-        _streamInfo = new StreamInfo(StreamName, StreamType, 1, 0.0, LSL.channel_format_t.cf_string, StreamId);
+        _streamInfo = new StreamInfo(StreamName, StreamType, 2, 0.0, LSL.channel_format_t.cf_string, StreamId);
         _outlet = new StreamOutlet(_streamInfo);
+
+        _sample = new string[2];
 
         return true;
     }
@@ -60,17 +62,36 @@ public class TargetElementLSLStream : MonoBehaviour
         // Get the target element SPO currently stored in the model
         SPO targetSPO = _model.TargetElementSPO;
 
-        if (targetSPO != null)
+        if (targetSPO == null)
         {
-            // Get the object ID of the target element
-            _sample = targetSPO.ObjectID.ToString();
-
-            // Send the sample to the LSL stream
-            _outlet.push_sample(new string[] { _sample });
-            // Debug.Log("Target element object ID sent to LSL stream: " + _sample);
-
-            // Clear the target element SPO in the model
-            _model.ClearTargetElement();
+            return;
         }
+
+        // Make sure to wait for the object ID to be set
+        float timer = 0;
+        while (targetSPO.ObjectID == -100 && timer < 5)
+        {
+            timer += Time.deltaTime;
+        }
+        if (targetSPO.ObjectID == -100)
+        {
+            // Show warning if object ID still not set after 5 seconds
+            Debug.LogWarning("Object ID not set yet.");
+        }
+
+        // Get the object ID and selectable pool index of the target element
+        string objectID = targetSPO.ObjectID.ToString();
+        string selectablePoolIndex = targetSPO.SelectablePoolIndex.ToString();
+        
+        _sample[0] = "ObjectID: " + objectID;
+        _sample[1] = "iSPO: " + selectablePoolIndex;
+
+        // Send the sample to the LSL stream
+        _outlet.push_sample(_sample);
+        // Debug.Log("Target element object ID sent to LSL stream: " + _sample[0]);
+        // Debug.Log("Target element selectable pool index sent to LSL stream: " + _sample[1]);
+
+        // Clear the target element SPO in the model
+        _model.ClearTargetElement();
     }
 }

--- a/Boccia-Unity/Assets/Boccia/BCI/TargetElementLSLStream.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/TargetElementLSLStream.cs
@@ -67,8 +67,10 @@ public class TargetElementLSLStream : MonoBehaviour
 
             // Send the sample to the LSL stream
             _outlet.push_sample(new string[] { _sample });
+            // Debug.Log("Target element object ID sent to LSL stream: " + _sample);
 
-            Debug.Log("Target element object ID sent to LSL stream: " + _sample);
+            // Clear the target element SPO in the model
+            _model.ClearTargetElement();
         }
     }
 }

--- a/Boccia-Unity/Assets/Boccia/BCI/TargetElementLSLStream.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/TargetElementLSLStream.cs
@@ -6,14 +6,17 @@ using BCIEssentials.StimulusObjects;
 
 public class TargetElementLSLStream : MonoBehaviour
 {
+    public string StreamName = "TargetElementStream";
+    public string StreamId = "target_element_stream_01";
+
     [Header("LSL Stream")]
     private StreamOutlet _outlet;
-    public string StreamName = "TargetElementStream";
-    private string StreamType = "Text";
-    public string StreamId = "target_element_stream_01";
+    private readonly string _StreamType = "Text";
     private StreamInfo _streamInfo;
     private string[] _sample;
     private BocciaModel _model;
+    private int _WaitTimeforObjectID = 5;   // Wait time for ObjectID to be populated [sec]
+    
     // Start is called before the first frame update
     void Start()
     {
@@ -33,7 +36,7 @@ public class TargetElementLSLStream : MonoBehaviour
             return false;
         }
 
-        _streamInfo = new StreamInfo(StreamName, StreamType, 2, 0.0, LSL.channel_format_t.cf_string, StreamId);
+        _streamInfo = new StreamInfo(StreamName, _StreamType, 2, 0.0, LSL.channel_format_t.cf_string, StreamId);
         _outlet = new StreamOutlet(_streamInfo);
 
         _sample = new string[2];
@@ -69,7 +72,7 @@ public class TargetElementLSLStream : MonoBehaviour
 
         // Make sure to wait for the object ID to be set
         float timer = 0;
-        while (targetSPO.ObjectID == -100 && timer < 5)
+        while (targetSPO.ObjectID == -100 && timer < _WaitTimeforObjectID)
         {
             timer += Time.deltaTime;
         }

--- a/Boccia-Unity/Assets/Boccia/BCI/TargetElementLSLStream.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/TargetElementLSLStream.cs
@@ -1,0 +1,74 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using LSL;
+using BCIEssentials.StimulusObjects;
+
+public class TargetElementLSLStream : MonoBehaviour
+{
+    [Header("LSL Stream")]
+    private StreamOutlet _outlet;
+    public string StreamName = "TargetElementStream";
+    private string StreamType = "Text";
+    public string StreamId = "target_element_stream_01";
+    private StreamInfo _streamInfo;
+    private string _sample;
+    private BocciaModel _model;
+    // Start is called before the first frame update
+    void Start()
+    {
+        // cache model
+        _model = BocciaModel.Instance;
+
+        if (_outlet == null)
+        {
+            InitializeStream();
+        }   
+    }
+
+    private bool InitializeStream()
+    {
+        if (_outlet != null)
+        {
+            return false;
+        }
+
+        _streamInfo = new StreamInfo(StreamName, StreamType, 1, 0.0, LSL.channel_format_t.cf_string, StreamId);
+        _outlet = new StreamOutlet(_streamInfo);
+
+        return true;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.S))
+        {
+            // Get and send the object ID of the target element when stimulus starts
+            SendTargetElementObjectID();
+        }
+    }
+
+    private void SendTargetElementObjectID()
+    {
+        if (_outlet == null)
+        {
+            Debug.Log("Stream not initialized");
+            return;
+        }
+
+        // Get the target element SPO currently stored in the model
+        SPO targetSPO = _model.TargetElementSPO;
+
+        if (targetSPO != null)
+        {
+            // Get the object ID of the target element
+            _sample = targetSPO.ObjectID.ToString();
+
+            // Send the sample to the LSL stream
+            _outlet.push_sample(new string[] { _sample });
+
+            Debug.Log("Target element object ID sent to LSL stream: " + _sample);
+        }
+    }
+}

--- a/Boccia-Unity/Assets/Boccia/BCI/TargetElementLSLStream.cs.meta
+++ b/Boccia-Unity/Assets/Boccia/BCI/TargetElementLSLStream.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d0207bb2c705e341b1e4563aecd220e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -55,6 +55,8 @@ public class BocciaModel : Singleton<BocciaModel>
     // get is public, set is private
     public bool BciTrained { get; private set; }
 
+    public int TargetElementID { get; private set; }
+
     // Expose the entire P300SettingsContainer via a property
     public P300SettingsContainer P300Settings => bocciaData.P300Settings;
 
@@ -510,6 +512,12 @@ public class BocciaModel : Singleton<BocciaModel>
         IsTraining = false;
         BciTrained = true;
         SendBciChangeEvent();
+    }
+
+    public void SetTargetElement(int targetElementID)
+    {
+        TargetElementID = targetElementID;
+        Debug.Log("Target element set to: " + TargetElementID);
     }
 
     // MARK: BCI Setting Defaults

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -519,7 +519,6 @@ public class BocciaModel : Singleton<BocciaModel>
     public void SetTargetElement(SPO targetSPO)
     {
         TargetElementSPO = targetSPO;
-        Debug.Log("TargetElementSPO type: " + TargetElementSPO.GetType());
     }
 
     // MARK: BCI Setting Defaults

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -7,6 +7,7 @@ using Unity.VisualScripting;
 using UnityEditor.UI;
 using UnityEngine;
 using UnityEngine.Rendering;
+using BCIEssentials.StimulusObjects;
 
 
 // BocciaModel implements the "business logic" for the game.  The BocciaModel 
@@ -55,7 +56,7 @@ public class BocciaModel : Singleton<BocciaModel>
     // get is public, set is private
     public bool BciTrained { get; private set; }
 
-    public int TargetElementID { get; private set; }
+    public SPO TargetElementSPO;
 
     // Expose the entire P300SettingsContainer via a property
     public P300SettingsContainer P300Settings => bocciaData.P300Settings;
@@ -514,10 +515,11 @@ public class BocciaModel : Singleton<BocciaModel>
         SendBciChangeEvent();
     }
 
-    public void SetTargetElement(int targetElementID)
+    // Store the SPO of the target element
+    public void SetTargetElement(SPO targetSPO)
     {
-        TargetElementID = targetElementID;
-        Debug.Log("Target element set to: " + TargetElementID);
+        TargetElementSPO = targetSPO;
+        Debug.Log("TargetElementSPO type: " + TargetElementSPO.GetType());
     }
 
     // MARK: BCI Setting Defaults

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -521,6 +521,11 @@ public class BocciaModel : Singleton<BocciaModel>
         TargetElementSPO = targetSPO;
     }
 
+    public void ClearTargetElement()
+    {
+        TargetElementSPO = null;
+    }
+
     // MARK: BCI Setting Defaults
     // These is triggered for the active BCI paradigm by the ResetBciSettingsToDefaults() public method below whenever the
     // "Reset to Default" button is pressed/ within the BCI Options menu, via the OnResetDefaultsClicked() method in BciOptionsMenuPresenter.cs

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -79,12 +79,28 @@ public class PlayScreenPresenter : MonoBehaviour
 
     private void addListenerToButton(Button button, UnityEngine.Events.UnityAction action)
     {
-        button.onClick.AddListener(action);
+        button.onClick.RemoveAllListeners(); // Remove any existing listeners
+        button.onClick.AddListener(() => HandleButtonClick(button, action));
+
         SPO buttonSPO = button.GetComponent<SPO>();
         if (buttonSPO != null)
         {
             buttonSPO.OnSelectedEvent.AddListener(() => button.GetComponent<SPO>().StopStimulus());
-            buttonSPO.OnSelectedEvent.AddListener(() => action());
+            buttonSPO.OnSelectedEvent.AddListener(() => HandleButtonClick(button, action));
+        }
+    }
+
+    private void HandleButtonClick(Button button, UnityEngine.Events.UnityAction action)
+    {
+        if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift))
+        {
+            // Store the button as the target element
+            Debug.Log("Target element is " + button.name);
+        }
+        else
+        {
+            // Execute the normal button action
+            action.Invoke();
         }
     }
 

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -16,6 +16,7 @@ public class PlayScreenPresenter : MonoBehaviour
     public Button randomBallButton;
     public Button separateBackButton;
     public Button separateDropButton;
+    private List<Button> _playButtons;
 
     [Header("Debug tools")]
     public bool echoSerialCommands = true;
@@ -48,6 +49,12 @@ public class PlayScreenPresenter : MonoBehaviour
         // Get the VirtualPlayFan's fan presenter component
         _fanPresenter = GameObject.Find("PlayControlFan").GetComponent<FanPresenter>();
 
+        _playButtons = new List<Button>()
+        {
+            resetRampButton,
+            randomBallButton,
+        };
+
         if (_model.UseSeparateButtons)
         {
             InitializeSeparateButtons();
@@ -61,6 +68,9 @@ public class PlayScreenPresenter : MonoBehaviour
     {
         separateBackButton.gameObject.SetActive(false); // False since we start with coarse fan
         separateDropButton.gameObject.SetActive(true);
+
+        _playButtons.Add(separateBackButton);
+        _playButtons.Add(separateDropButton);
 
         addListenersToSeparateButtons();
     }
@@ -95,7 +105,8 @@ public class PlayScreenPresenter : MonoBehaviour
         if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift))
         {
             // Store the button as the target element
-            Debug.Log("Target element is " + button.name);
+            int buttonID = _playButtons.IndexOf(button);
+            _model.SetTargetElement(buttonID);
         }
         else
         {

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -104,9 +104,9 @@ public class PlayScreenPresenter : MonoBehaviour
     {
         if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift))
         {
-            // Store the button as the target element
-            int buttonID = _playButtons.IndexOf(button);
-            _model.SetTargetElement(buttonID);
+            // Store the target button's SPO
+            SPO buttonSPO = button.GetComponent<SPO>();
+            _model.SetTargetElement(buttonSPO);
         }
         else
         {

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/PlayScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/PlayScreen.prefab
@@ -1846,6 +1846,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3425727482096386981}
   - component: {fileID: 259447462842585429}
+  - component: {fileID: 7070389972008775068}
   m_Layer: 5
   m_Name: PlayScreen
   m_TagString: Untagged
@@ -1888,6 +1889,20 @@ MonoBehaviour:
   echoSerialCommands: 1
   _arduinoIsNeeded: 0
   serialStatusIndicator: {fileID: 280350794043064211}
+--- !u!114 &7070389972008775068
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7062422457744525498}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d0207bb2c705e341b1e4563aecd220e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  StreamName: TargetElementStream_Play
+  StreamId: target_element_stream_02
 --- !u!1 &7973036634516842441
 GameObject:
   m_ObjectHideFlags: 0

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/VirtualPlayScreen.prefab
@@ -1998,6 +1998,7 @@ GameObject:
   - component: {fileID: 7764173004061172451}
   - component: {fileID: 3576948454555312335}
   - component: {fileID: 8716667809871874162}
+  - component: {fileID: 4579577047200106202}
   m_Layer: 6
   m_Name: VirtualPlayScreen
   m_TagString: Untagged
@@ -2061,6 +2062,20 @@ MonoBehaviour:
   _trialNumber: 0
   _fineFanSettings: {fileID: 11400000, guid: fa646aefe576f30429b0ff7334216751, type: 2}
   _coarseFanSettings: {fileID: 11400000, guid: 9bf211a5d6524d04a80756a708287313, type: 2}
+--- !u!114 &4579577047200106202
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4818931384772691849}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d0207bb2c705e341b1e4563aecd220e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  StreamName: TargetElementStream_VirtualPlay
+  StreamId: target_element_stream_01
 --- !u!1 &4844458911459802053
 GameObject:
   m_ObjectHideFlags: 0

--- a/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
@@ -101,12 +101,28 @@ public class VirtualPlayPresenter : MonoBehaviour
 
     private void AddListenerToButton(Button button, UnityEngine.Events.UnityAction action)
     {
-        button.onClick.AddListener(action);
+        button.onClick.RemoveAllListeners(); // Remove any existing listeners
+        button.onClick.AddListener(() => HandleButtonClick(button, action));
+
         SPO buttonSPO = button.GetComponent<SPO>();
         if (buttonSPO != null)
         {
             buttonSPO.OnSelectedEvent.AddListener(() => button.GetComponent<SPO>().StopStimulus());
-            buttonSPO.OnSelectedEvent.AddListener(() => action());
+            buttonSPO.OnSelectedEvent.AddListener(() => HandleButtonClick(button, action));
+        }
+    }
+
+    private void HandleButtonClick(Button button, UnityEngine.Events.UnityAction action)
+    {
+        if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift))
+        {
+            // Store the button as the target element
+            Debug.Log("Target element is " + button.name);
+        }
+        else
+        {
+            // Execute the normal button action
+            action.Invoke();
         }
     }
 

--- a/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
@@ -116,9 +116,9 @@ public class VirtualPlayPresenter : MonoBehaviour
     {
         if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift))
         {
-            // Store the button as the target element
-            int buttonID = virtualPlayButtons.IndexOf(button);
-            model.SetTargetElement(buttonID);
+            // Store the target button's SPO
+            SPO buttonSPO = button.GetComponent<SPO>();
+            model.SetTargetElement(buttonSPO);
         }
         else
         {

--- a/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
@@ -117,7 +117,8 @@ public class VirtualPlayPresenter : MonoBehaviour
         if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift))
         {
             // Store the button as the target element
-            Debug.Log("Target element is " + button.name);
+            int buttonID = virtualPlayButtons.IndexOf(button);
+            model.SetTargetElement(buttonID);
         }
         else
         {


### PR DESCRIPTION
This will close [Issue 145](https://github.com/kirtonBCIlab/boccia-bci/issues/145).

### Description
This is to keep track of the target UI element or fan segment with an LSL stream.

### Changes

1. Modified the UI button `OnClick` methods for `VirtualPlay` and `Play`. Now, if either `shift` key is held when the button is clicked, it will bypass the normal button method call (e.g. dropping the ball, resetting the ramp, etc.). Instead, it will save the `SPO` component of that button to the model.
2. Similarly, in `FanInteractions`, if `shift` is held when a fan segment is clicked, it will save the `SPO` of that segment to the model.
3. Added a new script called `TargetElementLSLStream` and attached it to `PlayScreen` and `VirtualPlayScreen`. When S is pressed, this script will get the `ObjectID` of the SPO component currently stored in the model. That ObjectID is sent as a string to an LSL stream. 
4. After sending the `ObjectID`, the value of `model.TargetElementSPO` is cleared. If `S` is pressed again without selecting a target element first, nothing will be sent to the `TargetElementLSLStream`.

### Testing

1. You can use LabRecorder and `xdf-import-example` from `boccia-bci-data-analysis` to test the values sent to the LSL stream. Or, you can just uncomment the Debug log in line 70 of `TargetElementLSLStream.cs`.
2. Start the game and navigate to Play or VirtualPlay.
3. Hold shift + click any UI button or fan segment to select a target. Press `S` to start the stimulus.
5. Pause the Unity runtime, and find the element you selected as the target in the scene. Make note of its SPO component `ObjectID`. 
6. You should see that the value sent to the LSL stream matches the selected element's `ObjectID`.