### PR TITLE
Add SettingsExporter component to Play screen

### DIFF
--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/PlayScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/PlayScreen.prefab
@@ -1846,6 +1846,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3425727482096386981}
   - component: {fileID: 259447462842585429}
+  - component: {fileID: 8197315134454872373}
   - component: {fileID: 7070389972008775068}
   m_Layer: 5
   m_Name: PlayScreen
@@ -1889,6 +1890,21 @@ MonoBehaviour:
   echoSerialCommands: 1
   _arduinoIsNeeded: 0
   serialStatusIndicator: {fileID: 280350794043064211}
+--- !u!114 &8197315134454872373
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7062422457744525498}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6918da7c742f07348b0b07714ae8c48f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _trialNumber: 0
+  _fineFanSettings: {fileID: 11400000, guid: fa646aefe576f30429b0ff7334216751, type: 2}
+  _coarseFanSettings: {fileID: 11400000, guid: 9bf211a5d6524d04a80756a708287313, type: 2}
 --- !u!114 &7070389972008775068
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Attached the script `SettingsExporter` as a component to the Play Screen, so that we can save the BCI settings when in Play mode as well as VirtualPlay.