### PR TITLE
Add setting to toggle separate buttons

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
@@ -57,7 +57,7 @@ public class FanGenerator : MonoBehaviour
    public void GenerateBackButton(FanSettings fanSettings, BackButtonPositioningMode positionMode)
    {
         // If using separate Back button, skip method
-        if (_model.UseSeparateButtons) return;
+        if (_model.P300Settings.SeparateButtons) return;
         
         // If no backbutton (i.e. for the coarse fan), skip method
         if (positionMode == BackButtonPositioningMode.None) return;
@@ -85,7 +85,7 @@ public class FanGenerator : MonoBehaviour
     public void GenerateDropButton(FanSettings fanSettings)
     {
         // If using separate Drop button, skip method
-        if (_model.UseSeparateButtons) return;
+        if (_model.P300Settings.SeparateButtons) return;
 
         int segments = 10; // Number of segments to approximate the arc
         Mesh fanMesh = GenerateFanMesh(0, fanSettings.Theta, fanSettings.InnerRadius - fanSettings.DropButtonHeight, fanSettings.InnerRadius - fanSettings.rowSpacing, segments);

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaData.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaData.cs
@@ -148,6 +148,7 @@ public class P300SettingsContainer
 {
     public TrainSettings Train = new TrainSettings();  // Settings related to training
     public TestSettings Test = new TestSettings();    // Settings related to testing
+    public bool SeparateButtons;
 
     // Nested class for P300 training settings
     [System.Serializable]

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -23,9 +23,6 @@ public class BocciaModel : Singleton<BocciaModel>
     public BocciaScreen CurrentScreen;
     private BocciaScreen PreviousScreen;
 
-    // Fan segment testing
-    public bool UseSeparateButtons { get; private set; }
-
     // Game
     public BocciaGameMode GameMode;
 
@@ -149,8 +146,6 @@ public class BocciaModel : Singleton<BocciaModel>
         // Send the change event after SimulatedRamp is ready
         SendRampChangeEvent();
         // These will fail to run if put in the Awake() method
-
-        UseSeparateButtons = true;
     }
 
     private void OnDisable()
@@ -549,6 +544,8 @@ public class BocciaModel : Singleton<BocciaModel>
         bocciaData.P300Settings.Test.StimulusOnDuration = 0.1f;
         bocciaData.P300Settings.Test.StimulusOffDuration = 0.075f;
         bocciaData.P300Settings.Test.FlashColour = Color.red;
+
+        bocciaData.P300Settings.SeparateButtons = false;
 
         // Note: SendBciChangeEvent() trigged within ResetBciOptionsToDefaults();
     }

--- a/Boccia-Unity/Assets/Boccia/UI/BciOptionsP300Settings.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/BciOptionsP300Settings.cs
@@ -47,6 +47,7 @@ public class BciOptionsP300Settings : MonoBehaviour
     public TMP_Dropdown testStimulusOnDurationDropdown;
     public TMP_Dropdown testStimulusOffDurationDropdown;
     public TMP_Dropdown testFlashColourDropdown;
+    public Toggle separateButtonsToggle;
 
     private BocciaModel _model;
 
@@ -186,6 +187,8 @@ public class BciOptionsP300Settings : MonoBehaviour
         testStimulusOnDurationDropdown.value = GetOnDurationDropdownIndex(testSettings.StimulusOnDuration);
         testStimulusOffDurationDropdown.value = GetOffDurationDropdownIndex(testSettings.StimulusOffDuration);
         testFlashColourDropdown.value = GetColourDropdownIndex(testSettings.FlashColour);
+        
+        separateButtonsToggle.isOn = _model.P300Settings.SeparateButtons;
 
         // Ensure the animation dropdowns are correctly enabled/disabled based on the feedback toggles
         UpdateShamSelectionAnimationInteractable(trainShamSelectionFeedbackToggle.isOn);
@@ -298,6 +301,7 @@ public class BciOptionsP300Settings : MonoBehaviour
         testStimulusOnDurationDropdown.onValueChanged.AddListener(OnChangeTestStimulusOnDuration);
         testStimulusOffDurationDropdown.onValueChanged.AddListener(OnChangeTestStimulusOffDuration);
         testFlashColourDropdown.onValueChanged.AddListener(OnChangeTestFlashColour);
+        separateButtonsToggle.onValueChanged.AddListener(OnChangeSeparateButtons);
     }
 
     // Helper methods to get the dropdown index based on duration
@@ -458,6 +462,11 @@ public class BciOptionsP300Settings : MonoBehaviour
     {
         var selectedColour = GetColourFromDropdownIndex(index);
         _model.SetBciOption(ref _model.P300Settings.Test.FlashColour, selectedColour);
+    }
+
+    private void OnChangeSeparateButtons(bool isOn)
+    {
+        _model.SetBciOption(ref _model.P300Settings.SeparateButtons, isOn);
     }
 
     // MARK: Update P300 Controller

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -55,10 +55,7 @@ public class PlayScreenPresenter : MonoBehaviour
             randomBallButton,
         };
 
-        if (_model.UseSeparateButtons)
-        {
-            InitializeSeparateButtons();
-        }
+        InitializeSeparateButtons();
 
         // Add listeners to Play buttons
         addListenersToPlayButtons();
@@ -66,13 +63,28 @@ public class PlayScreenPresenter : MonoBehaviour
 
     private void InitializeSeparateButtons()
     {
-        separateBackButton.gameObject.SetActive(false); // False since we start with coarse fan
-        separateDropButton.gameObject.SetActive(true);
-
         _playButtons.Add(separateBackButton);
         _playButtons.Add(separateDropButton);
 
         addListenersToSeparateButtons();
+
+        ToggleSeparateButtons(_model.P300Settings.SeparateButtons);
+    }
+
+    private void ToggleSeparateButtons(bool useSeparateButtons)
+    {
+        separateDropButton.gameObject.SetActive(useSeparateButtons);
+
+        // Set the back button to active if the fan is fine fan
+        if (_fanPresenter != null && (_fanPresenter.positioningMode == FanPositioningMode.CenterToRails))
+        {
+            separateBackButton.gameObject.SetActive(useSeparateButtons);
+            return;
+        }
+        else if (_fanPresenter != null && (_fanPresenter.positioningMode == FanPositioningMode.CenterToBase))
+        {
+            separateBackButton.gameObject.SetActive(false);
+        }
     }
 
     private void addListenersToPlayButtons()
@@ -147,7 +159,7 @@ public class PlayScreenPresenter : MonoBehaviour
     private void FanTypeChanged()
     {
         // Activate the separate back button (if in use) now that the fan changed to Fine Fan
-        if (_model.UseSeparateButtons && (_fanPresenter.positioningMode == FanPositioningMode.CenterToRails))
+        if (_model.P300Settings.SeparateButtons && (_fanPresenter.positioningMode == FanPositioningMode.CenterToRails))
         {
             separateBackButton.gameObject.SetActive(true);
         }
@@ -177,6 +189,8 @@ public class PlayScreenPresenter : MonoBehaviour
         {
             _readSerialCommandCoroutine = StartCoroutine(ReadSerialCommand());
         }
+
+        ToggleSeparateButtons(_model.P300Settings.SeparateButtons);
     }
 
     void OnDisable()

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/BciOptionsMenu.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/BciOptionsMenu.prefab
@@ -1991,6 +1991,26 @@ PrefabInstance:
       propertyPath: m_fontSizeBase
       value: 18
       objectReference: {fileID: 0}
+    - target: {fileID: 218244013008699023, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 218244013008699023, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 218244013008699023, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 218244013008699023, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 218244013008699023, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 223498616277354662, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -2143,6 +2163,30 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3506200580638878182, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506200580638878182, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506200580638878182, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506200580638878182, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506200580638878182, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3506200580638878182, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3713957710913505761, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
       propertyPath: m_fontSize
       value: 18
@@ -2264,6 +2308,30 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5613645247297931123, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5879811256229682155, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5879811256229682155, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5879811256229682155, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5879811256229682155, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5879811256229682155, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5879811256229682155, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
@@ -2458,6 +2526,46 @@ PrefabInstance:
     - target: {fileID: 7522066298310243991, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
       propertyPath: m_Name
       value: TrainNumSelectionsInput
+      objectReference: {fileID: 0}
+    - target: {fileID: 8139961127236838868, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8139961127236838868, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8139961127236838868, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 582.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8139961127236838868, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 303.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8139961127236838868, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -443
+      objectReference: {fileID: 0}
+    - target: {fileID: 8205087066874529516, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8205087066874529516, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8205087066874529516, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8205087066874529516, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8205087066874529516, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8257744065267190522, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
       propertyPath: m_AnchorMax.y

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/BciOptionsMenu.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/BciOptionsMenu.prefab
@@ -2587,6 +2587,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8581553552163632729, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
+      propertyPath: m_text
+      value: Use separate drop/back buttons
+      objectReference: {fileID: 0}
     - target: {fileID: 9094978950140901730, guid: 8bac6dea2a454405e87b152ccf944687, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/BciOptionsP300.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/BciOptionsP300.prefab
@@ -2425,7 +2425,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   trainNumFlashesInputField: {fileID: 8288877150480579501}
-  trainNumTrainingWindowsInputField: {fileID: 1914573824707988307}
+  trainNumTrainingSelectionsInputField: {fileID: 0}
   trainTargetAnimationDropdown: {fileID: 4133074186262527802}
   trainShamSelectionFeedbackToggle: {fileID: 8071189948061836363}
   trainShamSelectionAnimationDropdown: {fileID: 5407607285925191507}
@@ -2440,6 +2440,7 @@ MonoBehaviour:
   testStimulusOnDurationDropdown: {fileID: 6760720784470214230}
   testStimulusOffDurationDropdown: {fileID: 2248103270412371685}
   testFlashColourDropdown: {fileID: 341120287138695433}
+  bciControllerManager: {fileID: 0}
 --- !u!114 &124571744188632792
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6670,6 +6671,82 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4086795436375227095
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 294594339250498417}
+  - component: {fileID: 2188071223586002353}
+  - component: {fileID: 7629278209352551474}
+  m_Layer: 0
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &294594339250498417
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4086795436375227095}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1624105670994645695}
+  m_Father: {fileID: 2645209217103370165}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 42, y: 42}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!222 &2188071223586002353
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4086795436375227095}
+  m_CullTransparentMesh: 1
+--- !u!114 &7629278209352551474
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4086795436375227095}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &4108992428016113234
 GameObject:
   m_ObjectHideFlags: 0
@@ -8553,6 +8630,140 @@ MonoBehaviour:
   m_fontStyle: 0
   m_HorizontalAlignment: 1
   m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &5072431486960743142
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5056873544173521086}
+  - component: {fileID: 5449734871459891565}
+  - component: {fileID: 8581553552163632729}
+  m_Layer: 0
+  m_Name: SeparateButtonsText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5056873544173521086
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5072431486960743142}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 218244013008699023}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 300, y: 25}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &5449734871459891565
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5072431486960743142}
+  m_CullTransparentMesh: 1
+--- !u!114 &8581553552163632729
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5072431486960743142}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Toggle Separate Buttons
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: af5aa117d756b4746a28940d43056963, type: 2}
+  m_sharedMaterial: {fileID: -7470251019685361148, guid: af5aa117d756b4746a28940d43056963, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 28
+  m_fontSizeBase: 28
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0
@@ -10565,6 +10776,91 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6382624467314601788
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2645209217103370165}
+  - component: {fileID: 6577012362561536190}
+  m_Layer: 0
+  m_Name: SeparateButtonsToggle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2645209217103370165
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6382624467314601788}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 294594339250498417}
+  m_Father: {fileID: 218244013008699023}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 125, y: -8}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!114 &6577012362561536190
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6382624467314601788}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    m_PressedColor: {r: 0, g: 0, b: 0, a: 1}
+    m_SelectedColor: {r: 1, g: 1, b: 1, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 7629278209352551474}
+  toggleTransition: 1
+  graphic: {fileID: 6658064385202803665}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_IsOn: 0
 --- !u!1 &6405214153623244536
 GameObject:
   m_ObjectHideFlags: 0
@@ -10871,6 +11167,7 @@ RectTransform:
   - {fileID: 7107435234690101885}
   - {fileID: 1784408964563574523}
   - {fileID: 8257744065267190522}
+  - {fileID: 218244013008699023}
   m_Father: {fileID: 6305663653189317526}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -13481,6 +13778,81 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7710238224251449500
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1624105670994645695}
+  - component: {fileID: 6096368668427066526}
+  - component: {fileID: 6658064385202803665}
+  m_Layer: 0
+  m_Name: Checkmark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1624105670994645695
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7710238224251449500}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 294594339250498417}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 40, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6096368668427066526
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7710238224251449500}
+  m_CullTransparentMesh: 1
+--- !u!114 &6658064385202803665
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7710238224251449500}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10901, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &7712632684942504833
 GameObject:
   m_ObjectHideFlags: 0
@@ -13615,6 +13987,43 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &7788397173328813930
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 218244013008699023}
+  m_Layer: 0
+  m_Name: SeparateButtons
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &218244013008699023
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7788397173328813930}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5056873544173521086}
+  - {fileID: 2645209217103370165}
+  m_Father: {fileID: 9094978950140901730}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 54}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &7920215369930293677
 GameObject:
   m_ObjectHideFlags: 0

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/BciOptionsP300.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/BciOptionsP300.prefab
@@ -2440,6 +2440,7 @@ MonoBehaviour:
   testStimulusOnDurationDropdown: {fileID: 6760720784470214230}
   testStimulusOffDurationDropdown: {fileID: 2248103270412371685}
   testFlashColourDropdown: {fileID: 341120287138695433}
+  separateButtonsToggle: {fileID: 6577012362561536190}
   bciControllerManager: {fileID: 0}
 --- !u!114 &124571744188632792
 MonoBehaviour:

--- a/Boccia-Unity/Assets/Boccia/UI/TrainingPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/TrainingPresenter.cs
@@ -29,9 +29,6 @@ public class TrainingPresenter : MonoBehaviour
 
         // Generate the fan
         //fanPresenter.GenerateFan();
-
-        separateBackButton.gameObject.SetActive(_model.UseSeparateButtons);
-        separateDropButton.gameObject.SetActive(_model.UseSeparateButtons);
     }
 
     void OnEnable()
@@ -41,6 +38,9 @@ public class TrainingPresenter : MonoBehaviour
         {
             _model.WasChanged += ModelChanged;
             _model.BciChanged += BciChanged;
+
+            separateBackButton.gameObject.SetActive(_model.P300Settings.SeparateButtons);
+            separateDropButton.gameObject.SetActive(_model.P300Settings.SeparateButtons);
         }
 
         // Set the instruction text

--- a/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
@@ -59,10 +59,7 @@ public class VirtualPlayPresenter : MonoBehaviour
             randomJackButton,
         };
 
-        if (model.UseSeparateButtons)
-        {
-            InitializeSeparateButtons();
-        }
+        InitializeSeparateButtons();
 
         // Add listeners to Virtual Play buttons
         AddListenersToVirtualPlayButtons();
@@ -74,15 +71,39 @@ public class VirtualPlayPresenter : MonoBehaviour
         ConnectTestingButtons();
     }
 
+    void OnEnable()
+    {
+        if (model == null)
+        {
+            return;
+        }
+
+        ToggleSeparateButtons(model.P300Settings.SeparateButtons);
+    }
+
     private void InitializeSeparateButtons()
     {
-        separateBackButton.gameObject.SetActive(false); // False since we start with coarse fan
-        separateDropButton.gameObject.SetActive(true);
-
         virtualPlayButtons.Add(separateBackButton);
         virtualPlayButtons.Add(separateDropButton);
 
         AddListenersToSeparateButtons();
+
+        ToggleSeparateButtons(model.P300Settings.SeparateButtons);
+    }
+
+    private void ToggleSeparateButtons(bool useSeparateButtons)
+    {
+        separateDropButton.gameObject.SetActive(useSeparateButtons);
+
+        // Set the back button to active if the fan is fine fan
+        if (_fanPresenter != null && (_fanPresenter.positioningMode == FanPositioningMode.CenterToRails))
+        {
+            separateBackButton.gameObject.SetActive(useSeparateButtons);
+        }
+        else if (_fanPresenter != null && (_fanPresenter.positioningMode == FanPositioningMode.CenterToBase))
+        {
+            separateBackButton.gameObject.SetActive(false);
+        }
     }
 
     private void AddListenersToVirtualPlayButtons()
@@ -159,7 +180,7 @@ public class VirtualPlayPresenter : MonoBehaviour
     private void FanTypeChanged()
     {
         // Activate the separate back button (if in use) now that the fan changed to Fine Fan
-        if (model.UseSeparateButtons && (_fanPresenter.positioningMode == FanPositioningMode.CenterToRails))
+        if (model.P300Settings.SeparateButtons && (_fanPresenter.positioningMode == FanPositioningMode.CenterToRails))
         {
             separateBackButton.gameObject.SetActive(true);
         }


### PR DESCRIPTION
This will close [Issue 159](https://github.com/kirtonBCIlab/boccia-bci/issues/159).

### Description
This is to add a setting to toggle the separate drop and back buttons. This branch `2502-fan-segment-testing` already has functionality to use the separate buttons instead of the drop and back fan segments. This PR is just to make it more convenient to change that setting, instead of changing a bool value in the model script.

### Changes

1. Added a Toggle Separate Buttons toggle setting to the BCI Options menu. It is part of the "Testing" panel, but this setting is the same for Training as well, since it affects how the fan generates. I thought having this setting in a UI menu (instead of an Inspector window) was easier since it applies to multiple scripts.
2. Modified FanGenerator to only generate the drop and back fan segments if the setting is `False`.
3. Modified `TrainingPresenter`, `PlayPresenter`, and `VirtualPlayPresenter` to activate/deactivate the separate buttons depending on the value of the `SeparateButtons` toggle setting.

### Testing

1. Navigate to the BCI Options menu. Change the "Toggle Separate Buttons" setting - the default is False.
2. Proceed to the `Training`, `Play`, or `Virtual Play` screen. If the `SeparateButtons` setting is set to `False`, the drop and back button will be part of the fan. If `True`, the buttons will be separate.
3. Return to the BCI Options menu and toggle the setting. Then go back to any of the screens. You should see that the drop and back button configuration has updated to match the setting.