### PR TITLE
Fix the training fan back button issue

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
@@ -139,6 +139,12 @@ public class FanPresenter : MonoBehaviour
                 CenterGameOptionsMenu();
                 fanGenerator.GenerateFanShape(_fineFan);
         }
+        // Make sure the fan positioning mode is Center North for the training fan
+        if (fanTypeScreen == BocciaScreen.TrainingScreen)
+        {
+            positioningMode = FanPositioningMode.CenterNorth;
+            StartCoroutine(GenerateFanCoroutine());
+        }
         // For all other cases, generate fan with a coroutine
         else
         {

--- a/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
@@ -139,12 +139,6 @@ public class FanPresenter : MonoBehaviour
                 CenterGameOptionsMenu();
                 fanGenerator.GenerateFanShape(_fineFan);
         }
-        // Make sure the fan positioning mode is Center North for the training fan
-        if (fanTypeScreen == BocciaScreen.TrainingScreen)
-        {
-            positioningMode = FanPositioningMode.CenterNorth;
-            StartCoroutine(GenerateFanCoroutine());
-        }
         // For all other cases, generate fan with a coroutine
         else
         {
@@ -204,7 +198,7 @@ public class FanPresenter : MonoBehaviour
     }
 
     /// <summary>
-    ///  Resets the fan to generate a coarse fan if the gameMode changes
+    ///  Resets the fan to generate a coarse fan if the gameMode changes, and a north fan in training
     /// </summary>
     private void ResetFanWhenPlayModeChanges()
     {
@@ -215,6 +209,10 @@ public class FanPresenter : MonoBehaviour
         {
             positioningMode = FanPositioningMode.CenterToBase;
             _lastPlayMode = currentPlayMode;
+        }
+        else if (!currentlyInPlayMode && fanTypeScreen == BocciaScreen.TrainingScreen)
+        {
+            positioningMode = FanPositioningMode.CenterNorth;
         }
     }
 


### PR DESCRIPTION
This will close [Issue 166](https://github.com/kirtonBCIlab/boccia-bci/issues/166) and merge into `main`.

### Description
If you opened Virtual Play or Play, and then went to Training, the training fan would be missing the back button. Also, it would generate the annotations.

### Changes

- In `FanPresenter` I added logic to ensure the `positioningMode` is set to `CenterNorth` before generating the fan on the Training screen.

### Testing

1. Navigate to Training and note that the fan generates with the back button and without annotations.
2. Navigate to either Play or Virtual Play, then back to Training. You should see that the training fan now generates properly with the back button and without annotations, every time you open Training.