### PR TITLE
Fix face sprite orientation

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
@@ -18,14 +18,23 @@ public class FanGenerator : MonoBehaviour
 
     [Header("Stimulus Settings")]
     public Sprite faceSprite;
+    [SerializeField]
+    private GameObject faceSpriteRotationCorrector;
     private GameObject spriteObject;
     private BocciaStimulusType _stimulusType;
+
+    private FanPositioningMode _fanPositioningMode;
 
     private BocciaModel _model;
 
     void Start()
     {
         _model = BocciaModel.Instance;
+    }
+
+    public void SetFanPositioningMode(FanPositioningMode fanPositioningMode)
+    {
+        _fanPositioningMode = fanPositioningMode;
     }
 
     public void GenerateFanShape(FanSettings fanSettings)
@@ -60,12 +69,8 @@ public class FanGenerator : MonoBehaviour
         GameObject fanSegment = CreateMeshObject("FanSegment", fanMesh);
         Vector3 fanSegmentMidpoint = CalculateSegmentMidpoint(startAngle, endAngle, innerRadius, outerRadius);
 
-        if (IsFaceSpriteStimulus())
-        {
-            Quaternion spriteRotation = Quaternion.Euler(0, 0, 0);
-            Vector3 spriteScale = new Vector3(0.05f, 0.05f, 0.05f);
-            CreateSegmentSprite(fanSegment, fanSegmentMidpoint, spriteRotation, spriteScale);
-        }
+        Vector3 spriteScale = new Vector3(0.05f, 0.05f, 0.05f);
+        CreateSegmentSprite(fanSegment, fanSegmentMidpoint, spriteScale);
     }
 
    public void GenerateBackButton(FanSettings fanSettings, BackButtonPositioningMode positionMode)
@@ -98,9 +103,8 @@ public class FanGenerator : MonoBehaviour
 
         if (IsFaceSpriteStimulus())
         {
-            Quaternion spriteRotation = Quaternion.Euler(0, 0, -90);
             Vector3 spriteScale = new Vector3(0.1f, 0.1f, 0.1f);
-            CreateSegmentSprite(backButton, backButtonMidpoint, spriteRotation, spriteScale);
+            CreateSegmentSprite(backButton, backButtonMidpoint, spriteScale);
         }
     }
 
@@ -118,9 +122,8 @@ public class FanGenerator : MonoBehaviour
 
         if (IsFaceSpriteStimulus())
         {
-            Quaternion spriteRotation = Quaternion.Euler(0, 0, 0);
             Vector3 spriteScale = new Vector3(0.05f, 0.05f, 0.05f);
-            CreateSegmentSprite(dropButton, dropButtonMidpoint, spriteRotation, spriteScale);
+            CreateSegmentSprite(dropButton, dropButtonMidpoint, spriteScale);
         }
     }
 
@@ -368,7 +371,7 @@ public class FanGenerator : MonoBehaviour
         }
     }
 
-    public void CreateSegmentSprite(GameObject segment, Vector3 segmentMidPoint, Quaternion rotation, Vector3 scale)
+    public void CreateSegmentSprite(GameObject segment, Vector3 segmentMidPoint, Vector3 scale)
     {
         // Create GameObject for the face sprite as a child of the fan segment
         spriteObject = new GameObject("FaceSprite");
@@ -379,8 +382,20 @@ public class FanGenerator : MonoBehaviour
         // Set the transform of the sprite object based on the segment mid point
         Vector3 spriteObjectPosition = new Vector3(segmentMidPoint.x, segmentMidPoint.y, -0.01f);
         spriteObject.transform.localPosition = spriteObjectPosition;
-        spriteObject.transform.localRotation = rotation;
         spriteObject.transform.localScale = scale;
+
+        // Set the rotation of the sprite object
+        Quaternion spriteRotation;
+        if (_fanPositioningMode == FanPositioningMode.CenterToRails)
+        {
+            spriteRotation = Quaternion.Euler(-90, faceSpriteRotationCorrector.transform.eulerAngles.y, 0);
+        }
+        else
+        {
+            spriteRotation = Quaternion.Euler(90, 0, 0);
+        }
+
+        spriteObject.transform.rotation = spriteRotation;
 
         // Disable sprite initially
         spriteObject.SetActive(false);

--- a/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
@@ -19,6 +19,7 @@ public class FanGenerator : MonoBehaviour
     [Header("Stimulus Settings")]
     public Sprite faceSprite;
     [SerializeField]
+    [Tooltip("Set this to the Shaft Adapter GameObject for Play and Virtual Play fans")]
     private GameObject faceSpriteRotationCorrector;
     private GameObject spriteObject;
     private BocciaStimulusType _stimulusType;

--- a/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanPresenter.cs
@@ -162,6 +162,9 @@ public class FanPresenter : MonoBehaviour
         // Reset to original rotation to avoid cumulative effects
         CenterToOrigin();
 
+        // Set positioning mode
+        fanGenerator.SetFanPositioningMode(positioningMode);
+
         // Get positioning mode and apply the corresponding offset    
         switch (positioningMode)
         {

--- a/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
+++ b/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
@@ -2491,6 +2491,10 @@ PrefabInstance:
       propertyPath: annotationFontSize
       value: 5
       objectReference: {fileID: 0}
+    - target: {fileID: 8798665786887840363, guid: 1be0eb6300d20d144979fdd1fb66a6e7, type: 3}
+      propertyPath: faceSpriteRotationCorrector
+      value: 
+      objectReference: {fileID: 1889748628}
     - target: {fileID: 8856341190636702082, guid: 1be0eb6300d20d144979fdd1fb66a6e7, type: 3}
       propertyPath: m_LocalPosition.y
       value: -2.26
@@ -2824,6 +2828,26 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3014206942168411893, guid: 67284b57dff4747ecbe18ccca03cfe89, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3181026568577639344, guid: 67284b57dff4747ecbe18ccca03cfe89, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3181026568577639344, guid: 67284b57dff4747ecbe18ccca03cfe89, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3181026568577639344, guid: 67284b57dff4747ecbe18ccca03cfe89, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3181026568577639344, guid: 67284b57dff4747ecbe18ccca03cfe89, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3181026568577639344, guid: 67284b57dff4747ecbe18ccca03cfe89, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
@@ -5213,6 +5237,11 @@ GameObject:
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 2611488574058446249, guid: fb7c8d71ccb9bc64896debf946c0b3b1, type: 3}
   m_PrefabInstance: {fileID: 1883243472}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1889748628 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1477832253948530056, guid: 1be0eb6300d20d144979fdd1fb66a6e7, type: 3}
+  m_PrefabInstance: {fileID: 1226142658}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1896514662
 GameObject:


### PR DESCRIPTION
This will close [Issue 165](https://github.com/kirtonBCIlab/boccia-bci/issues/165): Fix face sprite orientation.

### Description
The face sprites were rotated sideways on the fine fan segments because of how the fine fan is generated.

### Changes

1. In general, the face sprite rotation is now set globally rather than locally (so that the rotation isn't tied to the rotation of the fan segments).
2. If the `FanPositioningMode` is `CenterToRails` (i.e. the fine fan), the face sprite rotation will align with the rotation of the `Shaft Adapter` GameObject. This way, the face sprites will be aligned with the ramp.
3.  Otherwise, the face sprites are set to all have the same rotation. This is the case for the `Training` fan, and the coarse fan in `Play` and `Virtual Play`.

### Testing

1. In the BCI Options menu, change the `StimulusType` settings to `FaceSprite`. 
2. Navigate to the Play or Virtual Play screens, and click any segment to switch to the fine fan.
3. Start the stimulus. You should see that the face sprites are now oriented correctly within the fan segments.
