### PR TITLE
Fix gradient stimulus size

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
@@ -151,6 +151,14 @@ public class FanGenerator : MonoBehaviour
         meshRenderer.material = material;
         meshRenderer.material.color = colour;
 
+        Bounds bounds = generatedMesh.bounds;
+        float segmentSize = Mathf.Max(bounds.size.x, bounds.size.y);
+
+        MaterialPropertyBlock materialPropertyBlock = new MaterialPropertyBlock();
+        meshRenderer.GetPropertyBlock(materialPropertyBlock);
+        materialPropertyBlock.SetFloat("_SegmentSize", segmentSize);
+        meshRenderer.SetPropertyBlock(materialPropertyBlock);
+
         return meshObject;
     }
 

--- a/Boccia-Unity/Assets/Boccia/UI/StimulusPresentation/GradientStimulus/RadialGradientShaderFanSegment.shader
+++ b/Boccia-Unity/Assets/Boccia/UI/StimulusPresentation/GradientStimulus/RadialGradientShaderFanSegment.shader
@@ -3,8 +3,9 @@ Shader "Custom/RadialGradientShaderFanSegment"
     Properties
     {
         _GradientColor ("Gradient Color", Color) = (1, 0, 0, 1)  // Red color
-        _Radius ("Gradient Radius", Range(0.1, 1)) = 0.16 // How far the red extends
-        _Softness ("Gradient Softness", Range(0.1, 1)) = 0.45 // Controls how smooth the gradient is
+        _Radius ("Gradient Radius", Range(0.1, 1)) = 0.15 // How far the red extends
+        _Softness ("Gradient Softness", Range(0, 1)) = 0.45 // Controls how smooth the gradient is
+        _SegmentSize ("Segment Size", Float) = 1.0
     }
     SubShader
     {
@@ -32,6 +33,7 @@ Shader "Custom/RadialGradientShaderFanSegment"
             fixed4 _GradientColor;
             float _Radius;
             float _Softness;
+            float _SegmentSize;
 
             v2f vert (appdata_t v)
             {
@@ -45,12 +47,12 @@ Shader "Custom/RadialGradientShaderFanSegment"
             {
                 float2 center = float2(0.5, 0.5); // Center of texture UV
                 float dist = length(i.uv - center); // Distance from center
-                float gradient = smoothstep(_Radius - _Softness, _Radius + _Softness, dist); // Blend smoothly
-                return lerp(_GradientColor, fixed4(1,1,1,1), gradient); // Blend red to white
 
-                // float dist = i.uv.y; // Use the Y-axis of UVs as radial distance
-                // float gradient = smoothstep(_Radius - _Softness, _Radius + _Softness, dist); // Smooth transition
-                // return lerp(_GradientColor, fixed4(1,1,1,1), gradient);
+                float adjustedRadius = _Radius * _SegmentSize;
+                float adjustedSoftness = _Softness * _SegmentSize * 0.4;
+                float gradient = smoothstep(adjustedRadius - adjustedSoftness, adjustedRadius + adjustedSoftness, dist); // Blend smoothly
+
+                return lerp(_GradientColor, fixed4(1,1,1,1), gradient); 
             }
             ENDCG
         }

--- a/Boccia-Unity/Assets/Boccia/UI/StimulusPresentation/GradientStimulus/RadialGradientShaderFanSegment.shader
+++ b/Boccia-Unity/Assets/Boccia/UI/StimulusPresentation/GradientStimulus/RadialGradientShaderFanSegment.shader
@@ -3,7 +3,7 @@ Shader "Custom/RadialGradientShaderFanSegment"
     Properties
     {
         _GradientColor ("Gradient Color", Color) = (1, 0, 0, 1)  // Red color
-        _Radius ("Gradient Radius", Range(0.1, 1)) = 0.15 // How far the red extends
+        _Radius ("Gradient Radius", Range(0.1, 1)) = 0.10 // How far the red extends
         _Softness ("Gradient Softness", Range(0, 1)) = 0.45 // Controls how smooth the gradient is
         _SegmentSize ("Segment Size", Float) = 1.0
     }

--- a/Boccia-Unity/Assets/Boccia/UI/StimulusPresentation/GradientStimulus/RadialGradientShaderFanSegment.shader
+++ b/Boccia-Unity/Assets/Boccia/UI/StimulusPresentation/GradientStimulus/RadialGradientShaderFanSegment.shader
@@ -3,8 +3,8 @@ Shader "Custom/RadialGradientShaderFanSegment"
     Properties
     {
         _GradientColor ("Gradient Color", Color) = (1, 0, 0, 1)  // Red color
-        _Radius ("Gradient Radius", Range(0.1, 1)) = 0.10 // How far the red extends
-        _Softness ("Gradient Softness", Range(0, 1)) = 0.45 // Controls how smooth the gradient is
+        _Radius ("Gradient Radius", Range(0.1, 1)) = 0.10 // Base radius value
+        _Softness ("Gradient Softness", Range(0, 1)) = 0.18 // Base value to control how smooth the gradient is
         _SegmentSize ("Segment Size", Float) = 1.0
     }
     SubShader
@@ -49,7 +49,7 @@ Shader "Custom/RadialGradientShaderFanSegment"
                 float dist = length(i.uv - center); // Distance from center
 
                 float adjustedRadius = _Radius * _SegmentSize;
-                float adjustedSoftness = _Softness * _SegmentSize * 0.4;
+                float adjustedSoftness = _Softness * _SegmentSize;
                 float gradient = smoothstep(adjustedRadius - adjustedSoftness, adjustedRadius + adjustedSoftness, dist); // Blend smoothly
 
                 return lerp(_GradientColor, fixed4(1,1,1,1), gradient); 


### PR DESCRIPTION
This will close [Issue 173](https://github.com/kirtonBCIlab/boccia-bci/issues/173) to change the appearance of the gradient stimulus based on the size of the fan segment. This is to make sure the gradient effect works better for the smaller fine fan segments.

### Changes

- From `FanGenerator`, fan segment size is passed to the `RadialGradientShaderFanSegment` shader.
- The `RadialGradientShaderFanSegment` shader calculates the radius of the gradient by multiplying the fan segment size by a base value. It does the same for the gradient smoothness.

### Testing

- In BCI Options, set the stimulus type to `Gradient`.
- Start the stimulus in Virtual Play and observe the gradient effect.
- Switch to the fine fan by selecting any fan segment, then start the stimulus again. You should also see the gradient effect on the fine fan segments (i.e. white at the edges and changing to red towards the segment center).
