### PR TITLE
Fix target object indication issue

### DIFF
--- a/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
+++ b/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
@@ -437,48 +437,19 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 3771299433236743502, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
   m_PrefabInstance: {fileID: 1825258637}
   m_PrefabAsset: {fileID: 0}
---- !u!23 &147257020
-MeshRenderer:
+--- !u!114 &147257026
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 147257014}
   m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce7290849ae141245a87db13adfc695f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bocciaAnimation: 0
 --- !u!1 &171429499 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 8476152213448098857, guid: 6a619933318bf764aa5fb150788918f3, type: 3}
@@ -2160,7 +2131,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 281971961862754810, guid: 478a387523a05364c8d059c19c67e161, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 150.00006
+      value: 150.00005
       objectReference: {fileID: 0}
     - target: {fileID: 1360815048455865100, guid: 478a387523a05364c8d059c19c67e161, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2335,6 +2306,24 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 478a387523a05364c8d059c19c67e161, type: 3}
+--- !u!1 &1198610533 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2771549185955087148, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
+  m_PrefabInstance: {fileID: 1825258637}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1198610540
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1198610533}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce7290849ae141245a87db13adfc695f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bocciaAnimation: 0
 --- !u!1001 &1226142658
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5105,7 +5094,9 @@ PrefabInstance:
       propertyPath: StartTrainingStimulusEvent.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: DefaultScaleEffectOn
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 380558121869246137, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
+    - {fileID: 897484176359082770, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
@@ -5114,13 +5105,19 @@ PrefabInstance:
       addedObject: {fileID: 1098483546}
     - targetCorrespondingSourceObject: {fileID: 3771299433236743502, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 147257020}
+      addedObject: {fileID: 147257026}
     - targetCorrespondingSourceObject: {fileID: 9167880548560717550, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
       insertIndex: -1
       addedObject: {fileID: 598475558}
     - targetCorrespondingSourceObject: {fileID: 5281748401890387066, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
       insertIndex: -1
       addedObject: {fileID: 1264503755}
+    - targetCorrespondingSourceObject: {fileID: 2379991372603170479, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1906608570}
+    - targetCorrespondingSourceObject: {fileID: 2771549185955087148, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1198610540}
   m_SourcePrefab: {fileID: 100100000, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
 --- !u!4 &1825258638 stripped
 Transform:
@@ -5405,6 +5402,24 @@ Light:
   m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
+--- !u!1 &1906608563 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2379991372603170479, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
+  m_PrefabInstance: {fileID: 1825258637}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1906608570
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1906608563}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce7290849ae141245a87db13adfc695f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  bocciaAnimation: 0
 --- !u!1 &2146497313
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
This is for [Issue 179](https://github.com/kirtonBCIlab/boccia-bci/issues/179) to fix the problem where the target object in Training wasn't appearing yellow.

### Description

- It turns out that the `RandomJackButton`, `SeparateBackButton`, and `SeparateDropButton` UI buttons didn't have the `BCITargetAnimations` script attached, which is why the target indication animation (color change to yellow) didn't happen for those objects.

### Changes

- Added the BCITargetAnimation script to the objects that were missing it. I also had to remove the mesh renderer component from those objects in order for the animation to work (the other UI buttons also do not have a mesh renderer).

### Testing

- In the BCI Options menu, select the option to use separate drop and back buttons, then navigate to Training.
- The easiest way to test this is to disable the `TrainingControlFan` object before starting training, so that only the UI buttons will be active. You should see that all of the UI objects can change to yellow as the targets. The three buttons that this PR applies to are Object 1, Object 4, and Object 5.