### PR TITLE
Fix game options menu fan issue caused by face sprites

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
@@ -389,6 +389,12 @@ public class FanGenerator : MonoBehaviour
 
     public void CreateSegmentSprite(GameObject segment, Vector3 segmentMidPoint, float segmentHeight)
     {
+        // Skip this method for the game options menu fan
+        if (_model.CurrentScreen == BocciaScreen.GameOptions)
+        {
+            return;
+        }
+
         // Create GameObject for the face sprite as a child of the fan segment
         spriteObject = new GameObject("FaceSprite");
         spriteObject.transform.SetParent(segment.transform);

--- a/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
@@ -78,7 +78,11 @@ public class FanGenerator : MonoBehaviour
         Vector3 fanSegmentMidpoint = CalculateSegmentMidpoint(startAngle, endAngle, innerRadius, outerRadius);
         float fanSegmentHeight = CalculateFanSegmentHeight(innerRadius, outerRadius);
 
-        CreateSegmentSprite(fanSegment, fanSegmentMidpoint, fanSegmentHeight);
+        // Create the face sprite objects if stimulus is set to face sprite
+        if (IsFaceSpriteStimulus())
+        {
+            CreateSegmentSprite(fanSegment, fanSegmentMidpoint, fanSegmentHeight);
+        }
     }
 
    public void GenerateBackButton(FanSettings fanSettings, BackButtonPositioningMode positionMode)


### PR DESCRIPTION
This is for [Issue 182](https://github.com/kirtonBCIlab/boccia-bci/issues/182).

### Description
Trying to open the Game Options menu caused an error because it was trying to generate the face sprite objects on the game options menu fan.

### Changes

1. The `CreateSegmentSprite()` method in `FanGenerator` now checks if the current screen is the Game Options menu. If it is, it skips the rest of the method.
2. Before calling the `CreateSegmentSprite()` method for the regular fan segments, it checks if the stimulus type is set to FaceSprite, similar to what is done for the back button and drop button face sprites. This is to avoid unnecessary calls to `CreateSegmentSprite()`.

### Testing

1. Set the stimulus type to Face Sprite.
2. From the hamburger menu, try to open the Game Options menu. It should now open normally, and without any errors thrown.