### PR TITLE
Indicate in the console when target is selected

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanInteractions.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanInteractions.cs
@@ -81,7 +81,8 @@ public class FanInteractions : MonoBehaviour, IPointerClickHandler
             // Store the target segment's SPO
             SPO segmentSPO = segment.GetComponent<SPO>();
             _model.SetTargetElement(segmentSPO);
-            Debug.Log($"Target element set: {segment.name}");
+            _model.IncrementTargetCount();
+            Debug.Log($"Target #{_model.TargetCount} set: {segment.name}");
             return;
         }
 

--- a/Boccia-Unity/Assets/Boccia/BCI/FanInteractions.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanInteractions.cs
@@ -81,6 +81,7 @@ public class FanInteractions : MonoBehaviour, IPointerClickHandler
             // Store the target segment's SPO
             SPO segmentSPO = segment.GetComponent<SPO>();
             _model.SetTargetElement(segmentSPO);
+            Debug.Log($"Target element set: {segment.name}");
             return;
         }
 

--- a/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
+++ b/Boccia-Unity/Assets/Boccia/Model/BocciaModel.cs
@@ -54,6 +54,7 @@ public class BocciaModel : Singleton<BocciaModel>
     public bool BciTrained { get; private set; }
 
     public SPO TargetElementSPO;
+    public int TargetCount;
 
     // Expose the entire P300SettingsContainer via a property
     public P300SettingsContainer P300Settings => bocciaData.P300Settings;
@@ -514,6 +515,18 @@ public class BocciaModel : Singleton<BocciaModel>
     public void SetTargetElement(SPO targetSPO)
     {
         TargetElementSPO = targetSPO;
+    }
+
+    // Increment the target count
+    public void IncrementTargetCount()
+    {
+        TargetCount++;
+    }
+    
+    // Reset the count of the targets to 0
+    public void ResetTargetCount()
+    {
+        TargetCount = 0;
     }
 
     public void ClearTargetElement()

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -119,6 +119,7 @@ public class PlayScreenPresenter : MonoBehaviour
             // Store the target button's SPO
             SPO buttonSPO = button.GetComponent<SPO>();
             _model.SetTargetElement(buttonSPO);
+            Debug.Log($"Target element set: {button.name}");
         }
         else
         {

--- a/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/PlayScreenPresenter.cs
@@ -119,7 +119,8 @@ public class PlayScreenPresenter : MonoBehaviour
             // Store the target button's SPO
             SPO buttonSPO = button.GetComponent<SPO>();
             _model.SetTargetElement(buttonSPO);
-            Debug.Log($"Target element set: {button.name}");
+            _model.IncrementTargetCount();
+            Debug.Log($"Target #{_model.TargetCount} set: {button.name}");
         }
         else
         {
@@ -192,6 +193,9 @@ public class PlayScreenPresenter : MonoBehaviour
         }
 
         ToggleSeparateButtons(_model.P300Settings.SeparateButtons);
+
+        // Reset target count
+        _model.ResetTargetCount();
     }
 
     void OnDisable()

--- a/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
@@ -80,6 +80,9 @@ public class VirtualPlayPresenter : MonoBehaviour
         }
 
         ToggleSeparateButtons(model.P300Settings.SeparateButtons);
+
+        // Reset target count
+        model.ResetTargetCount();
     }
 
     private void InitializeSeparateButtons()
@@ -141,7 +144,8 @@ public class VirtualPlayPresenter : MonoBehaviour
             // Store the target button's SPO
             SPO buttonSPO = button.GetComponent<SPO>();
             model.SetTargetElement(buttonSPO);
-            Debug.Log($"Target element set: {button.name}");
+            model.IncrementTargetCount();
+            Debug.Log($"Target #{model.TargetCount} set: {button.name}");
         }
         else
         {

--- a/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
+++ b/Boccia-Unity/Assets/Boccia/UI/VirtualPlayPresenter.cs
@@ -141,6 +141,7 @@ public class VirtualPlayPresenter : MonoBehaviour
             // Store the target button's SPO
             SPO buttonSPO = button.GetComponent<SPO>();
             model.SetTargetElement(buttonSPO);
+            Debug.Log($"Target element set: {button.name}");
         }
         else
         {


### PR DESCRIPTION
This is for [Issue 181](https://github.com/kirtonBCIlab/boccia-bci/issues/181).

### Description
This is to add Debug.Log statements that output to the Unity project console when a target is selected.

### Changes

1. After using `shift + click` to select a UI element or fan segment, it prints a statement to the console, which includes the target number (i.e. to keep track of the targets through 1-10). This count is reset every time you re-enter Virtual Play or Play.

### Testing

1. Go to Virtual Play and Play, and select any object using `shift + click`. You should see in the console a statement to indicate the target element selection.
2. Select another target with `shift + click`. The count in this console statement will increase (i.e. from `Target #1` to `Target #2`)
3. Leave the screen and enter it again. Select another target, and the count should start over at `Target #1`