### PR TITLE
Fix UI button spacing in training

### DIFF
--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/TrainingScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/TrainingScreen.prefab
@@ -535,7 +535,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: -349, y: -130}
-  m_SizeDelta: {x: 160, y: 60}
+  m_SizeDelta: {x: 162, y: 54}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8527510973247040559
 CanvasRenderer:
@@ -1158,7 +1158,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: 349, y: -130}
-  m_SizeDelta: {x: 160, y: 60}
+  m_SizeDelta: {x: 162, y: 54}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6513410849676388767
 CanvasRenderer:
@@ -1602,7 +1602,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: -349, y: -60}
-  m_SizeDelta: {x: 160, y: 60}
+  m_SizeDelta: {x: 162, y: 54}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8901219700621823254
 CanvasRenderer:
@@ -2516,7 +2516,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: 349, y: -60}
-  m_SizeDelta: {x: 160, y: 60}
+  m_SizeDelta: {x: 162, y: 54}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1070821836674170442
 CanvasRenderer:

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/TrainingScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/TrainingScreen.prefab
@@ -534,7 +534,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: -1.637, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -349, y: -130}
+  m_AnchoredPosition: {x: -349, y: -131}
   m_SizeDelta: {x: 162, y: 54}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8527510973247040559
@@ -1157,7 +1157,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: -1.637, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 349, y: -130}
+  m_AnchoredPosition: {x: 349, y: -131}
   m_SizeDelta: {x: 162, y: 54}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6513410849676388767

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/TrainingScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/TrainingScreen.prefab
@@ -890,7 +890,7 @@ GameObject:
   - component: {fileID: 9082072509012217209}
   - component: {fileID: 2425395178984046}
   m_Layer: 0
-  m_Name: VirtualPlayButtons
+  m_Name: TrainingButtons
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -904,7 +904,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2859724575470018110}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 5}
+  m_LocalPosition: {x: 0, y: 0, z: -40}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -919,7 +919,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: -9, y: -116.5}
+  m_AnchoredPosition: {x: -9, y: -117}
   m_SizeDelta: {x: 1101, y: 655}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &8930885327393908749

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/TrainingScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/TrainingScreen.prefab
@@ -313,7 +313,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2379991372603170479}
   m_LocalRotation: {x: -0.014286327, y: -0, z: -0, w: 0.99989796}
-  m_LocalPosition: {x: 0, y: 0, z: -11}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -321,9 +321,9 @@ RectTransform:
   - {fileID: 8411774231809376750}
   m_Father: {fileID: 3678344975101463026}
   m_LocalEulerAnglesHint: {x: -1.637, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 120, y: 250}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: -349, y: 250}
   m_SizeDelta: {x: 160, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4113570306159985421
@@ -524,7 +524,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2606448242657076652}
   m_LocalRotation: {x: -0.014286327, y: -0, z: -0, w: 0.99989796}
-  m_LocalPosition: {x: 0, y: 0, z: -11}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -694,7 +694,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2771549185955087148}
   m_LocalRotation: {x: -0.014286327, y: -0, z: -0, w: 0.99989796}
-  m_LocalPosition: {x: 0, y: 0, z: -11}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1147,7 +1147,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3771299433236743502}
   m_LocalRotation: {x: -0.014286327, y: -0, z: -0, w: 0.99989796}
-  m_LocalPosition: {x: 0, y: 0, z: -11}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1591,7 +1591,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5281748401890387066}
   m_LocalRotation: {x: -0.014286327, y: -0, z: -0, w: 0.99989796}
-  m_LocalPosition: {x: 0, y: 0, z: -11}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1833,7 +1833,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6428448526347787154}
   m_LocalRotation: {x: -0.014286327, y: -0, z: -0, w: 0.99989796}
-  m_LocalPosition: {x: 0, y: 0, z: -5}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2505,7 +2505,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9167880548560717550}
   m_LocalRotation: {x: -0.014286327, y: -0, z: -0, w: 0.99989796}
-  m_LocalPosition: {x: 0, y: 0, z: -11}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:

--- a/Boccia-Unity/Assets/Boccia/UI/Prefabs/TrainingScreen.prefab
+++ b/Boccia-Unity/Assets/Boccia/UI/Prefabs/TrainingScreen.prefab
@@ -532,9 +532,9 @@ RectTransform:
   - {fileID: 1962737795389981066}
   m_Father: {fileID: 3678344975101463026}
   m_LocalEulerAnglesHint: {x: -1.637, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 120, y: -130}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: -349, y: -130}
   m_SizeDelta: {x: 160, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8527510973247040559
@@ -1147,7 +1147,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3771299433236743502}
   m_LocalRotation: {x: -0.014286327, y: -0, z: -0, w: 0.99989796}
-  m_LocalPosition: {x: 0, y: 0, z: -8.714386}
+  m_LocalPosition: {x: 0, y: 0, z: -11}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1155,9 +1155,9 @@ RectTransform:
   - {fileID: 6667174063134992916}
   m_Father: {fileID: 3678344975101463026}
   m_LocalEulerAnglesHint: {x: -1.637, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -120.00009, y: -130}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 349, y: -130}
   m_SizeDelta: {x: 160, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6513410849676388767
@@ -1599,9 +1599,9 @@ RectTransform:
   - {fileID: 5759948592612266823}
   m_Father: {fileID: 3678344975101463026}
   m_LocalEulerAnglesHint: {x: -1.637, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 120.00006, y: -60}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: -349, y: -60}
   m_SizeDelta: {x: 160, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8901219700621823254
@@ -2505,7 +2505,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9167880548560717550}
   m_LocalRotation: {x: -0.014286327, y: -0, z: -0, w: 0.99989796}
-  m_LocalPosition: {x: 0, y: 0, z: -8.714386}
+  m_LocalPosition: {x: 0, y: 0, z: -11}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -2513,9 +2513,9 @@ RectTransform:
   - {fileID: 1246555532251813303}
   m_Father: {fileID: 3678344975101463026}
   m_LocalEulerAnglesHint: {x: -1.637, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -120.00009, y: -60}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 349, y: -60}
   m_SizeDelta: {x: 160, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1070821836674170442

--- a/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
+++ b/Boccia-Unity/Assets/Scenes/Boccia Scene.unity
@@ -3862,10 +3862,6 @@ PrefabInstance:
       propertyPath: m_TagString
       value: BCI
       objectReference: {fileID: 0}
-    - target: {fileID: 1055580221340801892, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -130
-      objectReference: {fileID: 0}
     - target: {fileID: 1731453703119658755, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
       propertyPath: ObjectID
       value: -100
@@ -4038,10 +4034,6 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2854514153397762145, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -60
-      objectReference: {fileID: 0}
     - target: {fileID: 2859724575470018110, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
       propertyPath: m_Name
       value: TrainingButtons
@@ -4057,34 +4049,6 @@ PrefabInstance:
     - target: {fileID: 3512165304857073768, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
       propertyPath: m_TagString
       value: BCI
-      objectReference: {fileID: 0}
-    - target: {fileID: 3556022268195855465, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3556022268195855465, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3556022268195855465, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3556022268195855465, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3556022268195855465, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -11.000006
-      objectReference: {fileID: 0}
-    - target: {fileID: 3556022268195855465, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 120
-      objectReference: {fileID: 0}
-    - target: {fileID: 3556022268195855465, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -130
       objectReference: {fileID: 0}
     - target: {fileID: 3639073764761449564, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
       propertyPath: m_TagString
@@ -5077,10 +5041,6 @@ PrefabInstance:
     - target: {fileID: 7983456653138342303, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
       propertyPath: m_TagString
       value: BCI
-      objectReference: {fileID: 0}
-    - target: {fileID: 8012614959361384900, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -50
       objectReference: {fileID: 0}
     - target: {fileID: 8775156282939870954, guid: 4ec461a4c7b12064a9299ba234c99f06, type: 3}
       propertyPath: m_IsActive


### PR DESCRIPTION
This is for [Issue 185](https://github.com/kirtonBCIlab/boccia-bci/issues/185): Fix spacing between UI buttons in Training

(The PR is to merge into `2502-fan-segment-testing`)

### Description
This is to address the following:
- The spacing between the UI buttons on the right side of the training screen did not match the spacing of the button on left. (The buttons on the right were closer together).
- Compared to the UI buttons in Virtual Play, the Training UI buttons were closer together vertically.

### Changes

1. Adjusted the training UI button spacing to be the same for the "pairs" of buttons on each side of the Training screen.
2. Changed the training button size to match the size of the UI buttons in Virtual Play.
3. Changed the spacing between the Training buttons to match the Virtual Play button spacing. I had to reposition the Training buttons to be closer to the camera to appear similar in size to the Virtual Play buttons.

### Testing

1. Check the Training and Virtual Play UI buttons, and compare the spacing to see that it now matches more closely.