### PR TITLE
Fix face sprite sizing on fine fan

### DIFF
--- a/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
@@ -77,11 +77,12 @@ public class FanGenerator : MonoBehaviour
         GameObject fanSegment = CreateMeshObject("FanSegment", fanMesh);
         Vector3 fanSegmentMidpoint = CalculateSegmentMidpoint(startAngle, endAngle, innerRadius, outerRadius);
         float fanSegmentHeight = CalculateFanSegmentHeight(innerRadius, outerRadius);
+        float fanSegmentWidth = CalculateFanSegmentWidth(startAngle, endAngle);
 
         // Create the face sprite objects if stimulus is set to face sprite
         if (IsFaceSpriteStimulus())
         {
-            CreateSegmentSprite(fanSegment, fanSegmentMidpoint, fanSegmentHeight);
+            CreateSegmentSprite(fanSegment, fanSegmentMidpoint, fanSegmentHeight, fanSegmentWidth);
         }
     }
 
@@ -391,7 +392,7 @@ public class FanGenerator : MonoBehaviour
         }
     }
 
-    public void CreateSegmentSprite(GameObject segment, Vector3 segmentMidPoint, float segmentHeight)
+    public void CreateSegmentSprite(GameObject segment, Vector3 segmentMidPoint, float segmentHeight, float? segmentWidth = null)
     {
         // Skip this method for the game options menu fan
         if (_model.CurrentScreen == BocciaScreen.GameOptions)
@@ -408,8 +409,20 @@ public class FanGenerator : MonoBehaviour
         // Set the transform of the sprite object based on the segment mid point
         Vector3 spriteObjectPosition = new Vector3(segmentMidPoint.x, segmentMidPoint.y, -0.01f);
         spriteObject.transform.localPosition = spriteObjectPosition;
-        float currentSize = spriteRenderer.bounds.size.y;
-        float sizeRatio = segmentHeight / currentSize;
+        float currentSizeY = spriteRenderer.bounds.size.y;
+        float heightRatio = segmentHeight / currentSizeY;
+
+        float sizeRatio = 0;
+        if (segmentWidth != null)
+        {
+            float currentSizeX = spriteRenderer.bounds.size.x;
+            float widthRatio = segmentWidth.Value / currentSizeX;
+            sizeRatio = Mathf.Min(heightRatio, widthRatio);
+        }
+        else
+        {
+            sizeRatio = heightRatio;
+        }
 
         // Set the rotation and scaleof the sprite object
         Quaternion spriteRotation;
@@ -466,5 +479,11 @@ public class FanGenerator : MonoBehaviour
     {
         float segmentHeight = outerRadius - innerRadius;
         return segmentHeight;
+    }
+
+    private float CalculateFanSegmentWidth(float startAngle, float endAngle)
+    {
+        float segmentWidth = endAngle - startAngle;
+        return segmentWidth;
     }
 }   

--- a/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
@@ -26,7 +26,7 @@ public class FanGenerator : MonoBehaviour
     [SerializeField]
     private float _faceSpriteScaleFactorCoarseFan = 1.5f;
     [SerializeField]
-    private float _faceSpriteScaleFactorFineFan = 1.2f;
+    private float _faceSpriteScaleFactorFineFan = 0.9f;
     
     private GameObject spriteObject;
     private BocciaStimulusType _stimulusType;

--- a/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
+++ b/Boccia-Unity/Assets/Boccia/BCI/FanGenerator.cs
@@ -16,7 +16,7 @@ public class FanGenerator : MonoBehaviour
 
     public GameObject fanAnnotations;
 
-    [Header("Stimulus Settings")]
+    [Header("Face Sprite Stimulus Settings")]
     public FaceSpriteSelector faceSpriteSelection;
 
     [SerializeField]
@@ -27,6 +27,10 @@ public class FanGenerator : MonoBehaviour
     private float _faceSpriteScaleFactorCoarseFan = 1.5f;
     [SerializeField]
     private float _faceSpriteScaleFactorFineFan = 0.9f;
+    [SerializeField]
+    private float _faceSpriteScaleFactorBackButton = 0.4f;
+    [SerializeField]
+    private float _faceSpriteScaleFactorDropButton = 1.2f;
     
     private GameObject spriteObject;
     private BocciaStimulusType _stimulusType;
@@ -117,8 +121,8 @@ public class FanGenerator : MonoBehaviour
 
         if (IsFaceSpriteStimulus())
         {
-            float faceSpriteHeight = backButtonHeight / 2.5f; // So the face sprite doesn't take up the entire back button
-            CreateSegmentSprite(backButton, backButtonMidpoint, faceSpriteHeight);
+            // float faceSpriteHeight = backButtonHeight / 2.5f; // So the face sprite doesn't take up the entire back button
+            CreateSegmentSprite(backButton, backButtonMidpoint, backButtonHeight);
         }
     }
 
@@ -392,7 +396,7 @@ public class FanGenerator : MonoBehaviour
         }
     }
 
-    public void CreateSegmentSprite(GameObject segment, Vector3 segmentMidPoint, float segmentHeight, float? segmentWidth = null)
+    private void CreateSegmentSprite(GameObject segment, Vector3 segmentMidPoint, float segmentHeight, float? segmentWidth = null)
     {
         // Skip this method for the game options menu fan
         if (_model.CurrentScreen == BocciaScreen.GameOptions)
@@ -426,23 +430,43 @@ public class FanGenerator : MonoBehaviour
 
         // Set the rotation and scaleof the sprite object
         Quaternion spriteRotation;
-        float faceSpriteScale;
         if (_fanPositioningMode == FanPositioningMode.CenterToRails)
         {
             spriteRotation = Quaternion.Euler(-90, faceSpriteRotationCorrector.transform.eulerAngles.y, 0);
-            faceSpriteScale = sizeRatio * _faceSpriteScaleFactorFineFan;
         }
         else
         {
             spriteRotation = Quaternion.Euler(90, 0, 0);
-            faceSpriteScale = sizeRatio * _faceSpriteScaleFactorCoarseFan;
         }
-
         spriteObject.transform.rotation = spriteRotation;
+
+        float faceSpriteScale = GetFaceSpriteScaleFactor(segment) * sizeRatio;
         spriteRenderer.transform.localScale = Vector3.one * faceSpriteScale;
 
         // Disable sprite initially
         spriteObject.SetActive(false);
+    }
+
+    private float GetFaceSpriteScaleFactor(GameObject segment)
+    {
+        if (segment.name == "BackButton")
+        {
+            return _faceSpriteScaleFactorBackButton; // Adjust this value as needed for the back button
+        }
+
+        if (segment.name == "DropButton")
+        {
+            return _faceSpriteScaleFactorDropButton; // Adjust this value as needed for the drop button
+        }
+
+        if (_fanPositioningMode == FanPositioningMode.CenterToRails)
+        {
+            return _faceSpriteScaleFactorFineFan;
+        }
+        else
+        {
+            return _faceSpriteScaleFactorCoarseFan;
+        }
     }
 
     private bool IsFaceSpriteStimulus()

--- a/Boccia-Unity/Assets/Boccia/BCI/RampControlFan.prefab
+++ b/Boccia-Unity/Assets/Boccia/BCI/RampControlFan.prefab
@@ -71,7 +71,7 @@ MonoBehaviour:
   faceSpriteSelection: {fileID: 0}
   faceSpriteRotationCorrector: {fileID: 0}
   _faceSpriteScaleFactorCoarseFan: 1.5
-  _faceSpriteScaleFactorFineFan: 1.2
+  _faceSpriteScaleFactorFineFan: 0.9
 --- !u!114 &-7705321522961072228
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
This is for [Issue 188](https://github.com/kirtonBCIlab/boccia-bci/issues/188) to merge in `fix-face-sprite-sizing-fine-fan`

### Changes

1. The face sprites were overlapping with each other in the fine fan when it was on its default settings. I made some small changes to the way the face sprite scale is calculated, and I lowered the face sprite scale factor variable for the fine fan.

### Testing

1. In the Game Options, select Reset To Defaults to make sure that the fine fan is set to its default size.
2. In Virtual Play or Play, select any segment on the coarse fan to switch to the fine fan. Start the stimulus, and verify that the fan segments do not overlap anymore.